### PR TITLE
Fix for Reqnroll.VisualStudio GH#7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [vNext]
+* Fix for GH7 - "Find step definitions usages command not visible for SpecFlow projects
 
 # v2024.1.49 - 2024-02-08
 

--- a/Reqnroll.VisualStudio/Editor/Commands/FindStepDefinitionUsagesCommand.cs
+++ b/Reqnroll.VisualStudio/Editor/Commands/FindStepDefinitionUsagesCommand.cs
@@ -29,9 +29,10 @@ public class FindStepDefinitionUsagesCommand : DeveroomEditorCommandBase, IDever
     {
         var status = base.QueryStatus(textView, commandKey);
 
+        var heuristicTest = textView.TextBuffer.CurrentSnapshot.GetText().Contains("Reqnroll") || textView.TextBuffer.CurrentSnapshot.GetText().Contains("SpecFlow");
         if (status != DeveroomEditorCommandStatus.NotSupported)
-            // very basic heuristic: if the word "Reqnroll" is in the content of the file, it might be a binding class
-            status = textView.TextBuffer.CurrentSnapshot.GetText().Contains("Reqnroll")
+            // very basic heuristic: if the word "Reqnroll" (or "SpecFlow" for backwards compatibility) is in the content of the file, it might be a binding class
+            status = heuristicTest
                 ? DeveroomEditorCommandStatus.Supported
                 : DeveroomEditorCommandStatus.NotSupported;
 


### PR DESCRIPTION
The "Find step definitions usages" command is not visible for SpecFlow projects

Modified the heuristic used when testing whether the command should be displayed; it used to search for the term 'Reqnroll' in the text of the current editor window, now changed to search for either Reqnroll or SpecFlow.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code. (most of the time mandatory)
- [X] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
