### PR TITLE
Gh11 find step def usages fails first time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * FIX for Create Step Definition Snippets Generates Reqnroll Using Statements for SpecFlow Projects #6
 * Fix for GH7 - "Find step definitions usages command not visible for SpecFlow projects
+* FIX for GH11: Find Step Definitions command fails for first time (partial fix)
 
 # v2024.1.49 - 2024-02-08
 

--- a/Reqnroll.VisualStudio/Editor/Commands/FindStepDefinitionUsagesCommand.cs
+++ b/Reqnroll.VisualStudio/Editor/Commands/FindStepDefinitionUsagesCommand.cs
@@ -1,4 +1,6 @@
 #nullable disable
+using static System.Windows.Forms.VisualStyles.VisualStyleElement;
+
 namespace Reqnroll.VisualStudio.Editor.Commands;
 
 [Export(typeof(IDeveroomCodeEditorCommand))]
@@ -49,7 +51,18 @@ public class FindStepDefinitionUsagesCommand : DeveroomEditorCommandBase, IDever
         var triggerPoint = textView.Caret.Position.BufferPosition;
 
         var project = IdeScope.GetProject(textBuffer);
-        if (project == null || !project.GetProjectSettings().IsReqnrollProject)
+        bool bindingsNotYetLoaded = false;
+        bool projectNotYetLoaded = project == null;
+        if (!projectNotYetLoaded)
+        {
+            Logger.LogVerbose("Find Step Definition Usages:PreExec: project loaded");
+            var bindingRegistry = project.GetDiscoveryService().BindingRegistryCache;
+            bindingsNotYetLoaded = (bindingRegistry == null || bindingRegistry.Value == ProjectBindingRegistry.Invalid);
+            if (bindingsNotYetLoaded)
+                Logger.LogVerbose($"Find Step Definition Usages: PreExec: binding registry not available: {(bindingRegistry == null ? "null" : "invalid")}");
+        }
+
+        if (project == null || !project.GetProjectSettings().IsReqnrollProject || bindingsNotYetLoaded )
         {
             IdeScope.Actions.ShowProblem(
                 "Unable to find step definition usages: the project is not detected to be a Reqnroll project or it is not initialized yet.");

--- a/Reqnroll.VisualStudio/Editor/Commands/FindUnusedStepDefinitionsCommand.cs
+++ b/Reqnroll.VisualStudio/Editor/Commands/FindUnusedStepDefinitionsCommand.cs
@@ -49,10 +49,21 @@
             var textBuffer = textView.TextBuffer;
 
             var project = IdeScope.GetProject(textBuffer);
-            if (project == null || !project.GetProjectSettings().IsReqnrollProject)
+            bool bindingsNotYetLoaded = false;
+            bool projectNotYetLoaded = project == null;
+            if (!projectNotYetLoaded)
+            {
+                Logger.LogVerbose("Find Unused Step Definitions: PreExec: project loaded");
+                var bindingRegistry = project.GetDiscoveryService().BindingRegistryCache;
+                bindingsNotYetLoaded = (bindingRegistry == null || bindingRegistry.Value == ProjectBindingRegistry.Invalid);
+                if (bindingsNotYetLoaded)
+                    Logger.LogVerbose($"Find Unused Step Definitions: PreExec: binding registry not available: {(bindingRegistry == null ? "null" : "invalid")}");
+            }
+
+            if (project == null || !project.GetProjectSettings().IsReqnrollProject || bindingsNotYetLoaded)
             {
                 IdeScope.Actions.ShowProblem(
-                    "Unable to find step definition usages: the project is not detected to be a Reqnroll project or it is not initialized yet.");
+                    "Unable to find unused step definitions: the project is not detected to be a Reqnroll project or it is not initialized yet.");
                 return true;
             }
 


### PR DESCRIPTION
…e first time.

This patch displays an error dialog when the StepDefinition binding registry is not yet fully populated (instead of current behavior of the command silently failing).

Modified PreExec to check for a valid Binding Registry. If one not found, an error dialog is displayed and the command exits.

Same modification made to 'Find Unused Step Definitions' command.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code. (most of the time mandatory)
- [X ] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
