### PR TITLE
Fix mispelling in define step command error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [vNext]
+* Fixed a mispelling in an error message in the DefineStepsCommand.
 
 # v2024.2.93 - 2024-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
 # [vNext]
-* Fixed a mispelling in an error message in the DefineStepsCommand.
 
 # v2024.2.93 - 2024-06-05
 

--- a/Reqnroll.VisualStudio/Editor/Commands/DefineStepsCommand.cs
+++ b/Reqnroll.VisualStudio/Editor/Commands/DefineStepsCommand.cs
@@ -148,7 +148,7 @@ public class DefineStepsCommand : DeveroomEditorCommandBase, IDeveroomFeatureEdi
 
         if (IdeScope.FileSystem.File.Exists(targetFile.FullName))
             if (IdeScope.Actions.ShowSyncQuestion("Overwrite file?",
-                    $"The selected step definition file '{targetFile}' already exists. By overwriting the existing file you might loose work. {Environment.NewLine}Do you want to overwrite the file?",
+                    $"The selected step definition file '{targetFile}' already exists. By overwriting the existing file you might lose work. {Environment.NewLine}Do you want to overwrite the file?",
                     defaultButton: MessageBoxResult.No) != MessageBoxResult.Yes)
                 return;
 


### PR DESCRIPTION
Fix a misspelled word in an error message within the DefineStepsCommand.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code. (most of the time mandatory)
- [X] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
