### PR TITLE
Fix unused step defs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # [vNext]
 
+## Improvements:
+
+* Find Unused Step Definitions Command: Improved handling of Step Definitions decorated with the 'StepDefinition' attribute. If a Step Definition is used in any Given/Then/When step in a Feature file, the step will no longer show.
+
+## Bug fixes:
+
+*Contributors of this release (in alphabetical order):* @UL-ChrisGlew
+
 # v2024.2.93 - 2024-06-05
 
 ## Improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 ## Improvements:
 
-* Find Unused Step Definitions Command: Improved handling of Step Definitions decorated with the 'StepDefinition' attribute. If a Step Definition is used in any Given/Then/When step in a Feature file, the step will no longer show.
-
-## Bug fixes:
+* Find Unused Step Definitions Command: Improved handling of Step Definitions decorated with the 'StepDefinition' attribute. If a Step Definition is used in any Given/Then/When step in a Feature file, the step will no longer show in the 'Find Unused Step Definitions' context menu.
 
 *Contributors of this release (in alphabetical order):* @UL-ChrisGlew
 

--- a/Reqnroll.VisualStudio/Editor/Services/UnusedStepDefinitionsFinder.cs
+++ b/Reqnroll.VisualStudio/Editor/Services/UnusedStepDefinitionsFinder.cs
@@ -18,8 +18,7 @@ public class UnusedStepDefinitionsFinder : StepFinderBase
         _ideScope = ideScope;
     }
 
-    public IEnumerable<ProjectStepDefinitionBinding> FindUnused(ProjectBindingRegistry bindingRegistry, 
-        string[] featureFiles, DeveroomConfiguration configuration)
+    public IEnumerable<ProjectStepDefinitionBinding> FindUnused(ProjectBindingRegistry bindingRegistry, string[] featureFiles, DeveroomConfiguration configuration)
     {
         var stepDefUsageCounts = bindingRegistry.StepDefinitions.ToDictionary(stepDef => stepDef, _ => 0);
         foreach (var ff in featureFiles)

--- a/Reqnroll.VisualStudio/Editor/Services/UnusedStepDefinitionsFinder.cs
+++ b/Reqnroll.VisualStudio/Editor/Services/UnusedStepDefinitionsFinder.cs
@@ -18,8 +18,7 @@ public class UnusedStepDefinitionsFinder : StepFinderBase
         _ideScope = ideScope;
     }
 
-    public IEnumerable<ProjectStepDefinitionBinding> FindUnused(ProjectBindingRegistry bindingRegistry,
-                                                        string[] featureFiles, DeveroomConfiguration configuration)
+    public IEnumerable<ProjectStepDefinitionBinding> FindUnused(ProjectBindingRegistry bindingRegistry, string[] featureFiles, DeveroomConfiguration configuration)
     {
         var stepDefUsageCounts = bindingRegistry.StepDefinitions.ToDictionary(stepDef => stepDef, _ => 0);
         foreach (var ff in featureFiles)
@@ -28,7 +27,9 @@ public class UnusedStepDefinitionsFinder : StepFinderBase
             foreach (var step in usedSteps) stepDefUsageCounts[step]++;
         }
 
-        return stepDefUsageCounts.Where(x => x.Value == 0).Select(x => x.Key);
+        var allUsedSteps = stepDefUsageCounts.Where(x => x.Value > 0).Select(x => x.Key).ToList();
+        var allUnusedSteps = stepDefUsageCounts.Where(x => x.Value == 0).Select(x => x.Key);
+        return allUnusedSteps.Where(x => !allUsedSteps.Any(y => y.Expression.Equals(x.Expression) && ReferenceEquals(x.Implementation, y.Implementation)));
     }
 
     protected IEnumerable<ProjectStepDefinitionBinding> FindUsed(ProjectBindingRegistry bindingRegistry,

--- a/Reqnroll.VisualStudio/Editor/Services/UnusedStepDefinitionsFinder.cs
+++ b/Reqnroll.VisualStudio/Editor/Services/UnusedStepDefinitionsFinder.cs
@@ -18,7 +18,8 @@ public class UnusedStepDefinitionsFinder : StepFinderBase
         _ideScope = ideScope;
     }
 
-    public IEnumerable<ProjectStepDefinitionBinding> FindUnused(ProjectBindingRegistry bindingRegistry, string[] featureFiles, DeveroomConfiguration configuration)
+    public IEnumerable<ProjectStepDefinitionBinding> FindUnused(ProjectBindingRegistry bindingRegistry, 
+        string[] featureFiles, DeveroomConfiguration configuration)
     {
         var stepDefUsageCounts = bindingRegistry.StepDefinitions.ToDictionary(stepDef => stepDef, _ => 0);
         foreach (var ff in featureFiles)

--- a/Tests/Reqnroll.VisualStudio.Tests/Editor/Commands/FindUnusedStepDefinitionsCommandTests.cs
+++ b/Tests/Reqnroll.VisualStudio.Tests/Editor/Commands/FindUnusedStepDefinitionsCommandTests.cs
@@ -39,4 +39,19 @@ public class FindUnusedStepDefinitionsCommandTests : CommandTestBase<FindUnusedS
             .HaveCount(2).And
             .Contain(mi => mi.Label == "Steps.cs(10,9): [When(\"I choose add\")] WhenIPressAdd");
     }
+
+
+    [Fact]
+    public async Task Cannot_find_an_unused_StepDefinition_With_StepDefinition_Attribute()
+    {
+        var stepDefinition = ArrangeStepDefinition(@"""I press add""", "StepDefinition");
+        var featureFile = ArrangeOneFeatureFile();
+        var (textView, command) = await ArrangeSut(stepDefinition, featureFile);
+
+        await InvokeAndWaitAnalyticsEvent(command, textView);
+
+        (ProjectScope.IdeScope.Actions as StubIdeActions)!.LastShowContextMenuItems.Should()
+            .HaveCount(1).And
+            .Contain(mi => mi.Label == "There are no unused step definitions");
+    }
 }

--- a/Tests/Reqnroll.VisualStudio.VsxStubs/StepDefinitions/MockableDiscoveryService.cs
+++ b/Tests/Reqnroll.VisualStudio.VsxStubs/StepDefinitions/MockableDiscoveryService.cs
@@ -1,3 +1,6 @@
+using Gherkin.CucumberMessages.Types;
+using Newtonsoft.Json;
+
 namespace Reqnroll.VisualStudio.VsxStubs.StepDefinitions;
 
 public class MockableDiscoveryService : DiscoveryService
@@ -22,11 +25,34 @@ public class MockableDiscoveryService : DiscoveryService
     {
         var discoveryResultProviderMock = new Mock<IDiscoveryResultProvider>(MockBehavior.Strict);
 
+        var allStepDefinitions = new List<StepDefinition>();
+        foreach (var stepDefinition in stepDefinitions)
+        {
+            if (stepDefinition.Type.Equals("StepDefinition"))
+            {
+                var serialized = JsonConvert.SerializeObject(stepDefinition);
+                var stepDefAttributes = new List<string>() { "Given", "Then", "When" };
+                foreach (string stepDefAttribute in stepDefAttributes)
+                {
+                    StepDefinition? clonedStepDef = JsonConvert.DeserializeObject<StepDefinition>(serialized);
+                    if (clonedStepDef != null)
+                    {
+                        clonedStepDef.Type = stepDefAttribute;
+                        allStepDefinitions.Add(clonedStepDef);
+                    }
+                }
+            }
+            else
+            {
+                allStepDefinitions.Add(stepDefinition);
+            }
+        }
+
         var discoveryService = new MockableDiscoveryService(projectScope, discoveryResultProviderMock)
         {
             LastDiscoveryResult = new DiscoveryResult
             {
-                StepDefinitions = stepDefinitions,
+                StepDefinitions = allStepDefinitions.ToArray(),
                 Hooks = Array.Empty<Hook>()
             }
         };


### PR DESCRIPTION
<!---
Thanks for helping to make Reqnroll better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻

You can delete these comment sections as you process them.
-->

### 🤔 What's changed?

The 'Find Unused Step Definitions' context menu should no longer show step definitions decorated with the 'StepDefinition' attribute as unused when one or more is used with a Given/Then/When.

### ⚡️ What's your motivation? 

Fix for #22. 

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

I've attempted to add a new unit test to test this. This involved adding some logic to correctly add a 'StepDefinition' attribute into the 'MockableDiscoveryService' - let me know if there's any better way of doing this.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
