### PR TITLE
GH16: Detect Existence of SpecFlow for Visual Studio Extension 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Improvements:
 
 * Find Unused Step Definitions Command: Improved handling of Step Definitions decorated with the 'StepDefinition' attribute. If a Step Definition is used in any Given/Then/When step in a Feature file, the step will no longer show in the 'Find Unused Step Definitions' context menu. (#24)
+* Detects Existence of SpecFlow for Visual Studio extension and show a warning (GH#16)
 
 ## Bug fixes:
 

--- a/Reqnroll.VisualStudio/Editor/Services/DeveroomTaggerProvider.cs
+++ b/Reqnroll.VisualStudio/Editor/Services/DeveroomTaggerProvider.cs
@@ -1,3 +1,5 @@
+using Reqnroll.VisualStudio.SpecFlowExtensionDetection;
+
 namespace Reqnroll.VisualStudio.Editor.Services;
 
 [Export(typeof(ITaggerProvider))]
@@ -7,15 +9,19 @@ namespace Reqnroll.VisualStudio.Editor.Services;
 public class DeveroomTaggerProvider : IDeveroomTaggerProvider
 {
     private readonly IIdeScope _ideScope;
+    private readonly SpecFlowExtensionDetectionService _detectionService;
 
     [ImportingConstructor]
-    public DeveroomTaggerProvider(IIdeScope ideScope)
+    public DeveroomTaggerProvider(IIdeScope ideScope, SpecFlowExtensionDetectionService specFlowExtensionDetectionService)
     {
+        _detectionService = specFlowExtensionDetectionService;
         _ideScope = ideScope;
     }
 
     public ITagger<T> CreateTagger<T>(ITextBuffer buffer) where T : ITag
     {
+        _detectionService?.CheckForSpecFlowExtensionOnce();
+
         if (buffer is not ITextBuffer2 buffer2)
             throw new InvalidOperationException($"Cannot assign {buffer.GetType()} to {typeof(ITextBuffer2)}");
 

--- a/Reqnroll.VisualStudio/Reqnroll.VisualStudio.csproj
+++ b/Reqnroll.VisualStudio/Reqnroll.VisualStudio.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net481</TargetFramework>

--- a/Reqnroll.VisualStudio/SpecFlowExtensionDetection/SpecFlowExtensionDetectionClassifier.cs
+++ b/Reqnroll.VisualStudio/SpecFlowExtensionDetection/SpecFlowExtensionDetectionClassifier.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.VisualStudio.Text.Classification;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Reqnroll.VisualStudio.SpecFlowExtensionDetection
+{
+    [Export(typeof(IClassifierProvider))]
+    [ContentType("gherkin")]
+    public class SpecFlowExtensionDetectionClassifierProvider : IClassifierProvider
+    {
+        private readonly SpecFlowExtensionDetectionService _detectionService;
+
+        public SpecFlowExtensionDetectionClassifierProvider(SpecFlowExtensionDetectionService detectionService)
+        {
+            _detectionService = detectionService;
+        }
+        public IClassifier GetClassifier(ITextBuffer textBuffer)
+        {
+            _detectionService.CheckForSpecFlowExtension();
+            return null;
+        }
+    }
+}

--- a/Reqnroll.VisualStudio/SpecFlowExtensionDetection/SpecFlowExtensionDetectionService.cs
+++ b/Reqnroll.VisualStudio/SpecFlowExtensionDetection/SpecFlowExtensionDetectionService.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Reqnroll.VisualStudio.SpecFlowExtensionDetection
+{
+    [Export]
+    public class SpecFlowExtensionDetectionService
+    {
+        private readonly IIdeScope _ideScope;
+        private bool _extensionExistenceChecked = false;
+        private bool _compatibilityAlertShown = false;
+
+        [ImportingConstructor]
+        public SpecFlowExtensionDetectionService(IIdeScope ideScope)
+        {
+            _ideScope = ideScope;
+        }
+
+        public void CheckForSpecFlowExtensionOnce()
+        {
+            if (_extensionExistenceChecked)
+                return;
+
+            CheckForSpecFlowExtension();
+        }
+
+        public void CheckForSpecFlowExtension()
+        {
+            if (_compatibilityAlertShown)
+                return;
+
+            _extensionExistenceChecked = true;
+            var specFlowExtensionDetected = AppDomain.CurrentDomain.GetAssemblies().Any(a =>
+                a.FullName.StartsWith("SpecFlow.VisualStudio"));
+
+            if (specFlowExtensionDetected && !_compatibilityAlertShown)
+            {
+                _compatibilityAlertShown = true;
+                _ideScope.Actions.ShowProblem(
+                                        $"We detected that both the 'Reqnroll for Visual Studio 2022' and the 'SpecFlow for Visual Studio 2022' extension have been installed in this Visual Studio instance.{Environment.NewLine}For the proper behavior you need to uninstall or disable one of these extensions in the 'Extensions / Manage Extensions' dialog.");
+
+            }
+        }
+    }
+}

--- a/Tests/Reqnroll.VisualStudio.Specs/StepDefinitions/ProjectSystemSteps.cs
+++ b/Tests/Reqnroll.VisualStudio.Specs/StepDefinitions/ProjectSystemSteps.cs
@@ -495,7 +495,7 @@ public class ProjectSystemSteps : Steps
 
     private IDeveroomTaggerProvider CreateTaggerProvider()
     {
-        var taggerProvider = new DeveroomTaggerProvider(_ideScope);
+        var taggerProvider = new DeveroomTaggerProvider(_ideScope, new SpecFlowExtensionDetection.SpecFlowExtensionDetectionService(_ideScope));
         var tagger = taggerProvider.CreateTagger<DeveroomTag>(_ideScope.CurrentTextView.TextBuffer);
         var span = new SnapshotSpan(_ideScope.CurrentTextView.TextSnapshot, 0, 0);
         tagger.GetUpToDateDeveroomTagsForSpan(span);

--- a/Tests/Reqnroll.VisualStudio.Tests/Editor/Commands/AutoFormatDocumentCommandTests.cs
+++ b/Tests/Reqnroll.VisualStudio.Tests/Editor/Commands/AutoFormatDocumentCommandTests.cs
@@ -9,7 +9,7 @@ public class AutoFormatDocumentCommandTests
     public AutoFormatDocumentCommandTests(ITestOutputHelper testOutputHelper)
     {
         _ideScope = new StubIdeScope(testOutputHelper);
-        _deveroomTaggerProvider = new DeveroomTaggerProvider(_ideScope);
+        _deveroomTaggerProvider = new DeveroomTaggerProvider(_ideScope, new SpecFlowExtensionDetection.SpecFlowExtensionDetectionService(_ideScope));
     }
 
     private AutoFormatDocumentCommand CreateSUT() => new(

--- a/Tests/Reqnroll.VisualStudio.Tests/Editor/Commands/AutoFormatTableCommandTests.cs
+++ b/Tests/Reqnroll.VisualStudio.Tests/Editor/Commands/AutoFormatTableCommandTests.cs
@@ -26,7 +26,7 @@ public class AutoFormatTableCommandTests
     public AutoFormatTableCommandTests(ITestOutputHelper testOutputHelper)
     {
         _ideScope = new StubIdeScope(testOutputHelper);
-        _taggerProvider = new DeveroomTaggerProvider(_ideScope);
+        _taggerProvider = new DeveroomTaggerProvider(_ideScope, new SpecFlowExtensionDetection.SpecFlowExtensionDetectionService(_ideScope));
     }
 
     private StubWpfTextView CreateTextView(TestText inputText, string newLine) =>

--- a/Tests/Reqnroll.VisualStudio.Tests/Editor/EditorTestBase.cs
+++ b/Tests/Reqnroll.VisualStudio.Tests/Editor/EditorTestBase.cs
@@ -171,7 +171,7 @@ public abstract class EditorTestBase
 
     protected static DeveroomTaggerProvider CreateTaggerProvider(IIdeScope ideScope)
     {
-        var taggerProvider = new DeveroomTaggerProvider(ideScope);
+        var taggerProvider = new DeveroomTaggerProvider(ideScope, new SpecFlowExtensionDetection.SpecFlowExtensionDetectionService(ideScope));
 
         return taggerProvider;
     }

--- a/Tests/Reqnroll.VisualStudio.Tests/Editor/Services/TaggerSut.cs
+++ b/Tests/Reqnroll.VisualStudio.Tests/Editor/Services/TaggerSut.cs
@@ -55,7 +55,7 @@ public record TaggerSut
     public ITagger<DeveroomTag> BuildFeatureFileTagger()
     {
         ProjectScope.Properties.AddProperty(typeof(IDeveroomTagParser), TagParser.Object);
-        var taggerProvider = new DeveroomTaggerProvider(IdeScope);
+        var taggerProvider = new DeveroomTaggerProvider(IdeScope, new SpecFlowExtensionDetection.SpecFlowExtensionDetectionService(IdeScope));
 
         var tagger = BuildTagger<FeatureFileTagger>(taggerProvider);
         tagger.TagsChanged += DeveroomTagger_TagsChanged;

--- a/Tests/Reqnroll.VisualStudio.VsxStubs/ProjectSystem/InMemoryStubProjectBuilder.cs
+++ b/Tests/Reqnroll.VisualStudio.VsxStubs/ProjectSystem/InMemoryStubProjectBuilder.cs
@@ -1,3 +1,5 @@
+using Reqnroll.VisualStudio.SpecFlowExtensionDetection;
+
 namespace Reqnroll.VisualStudio.VsxStubs.ProjectSystem;
 
 public class InMemoryStubProjectBuilder : IDisposable
@@ -15,7 +17,7 @@ public class InMemoryStubProjectBuilder : IDisposable
         bindingRegistryCache = project.Properties.GetProperty<IDiscoveryService>(typeof(IDiscoveryService))
             .BindingRegistryCache;
 
-        var taggerProvider = new DeveroomTaggerProvider(project.IdeScope);
+        var taggerProvider = new DeveroomTaggerProvider(project.IdeScope, new SpecFlowExtensionDetectionService(project.IdeScope));
         _tagger = taggerProvider.CreateTagger<DeveroomTag>(VisibleTextBuffer);
 
         _bindingRegistryChanged = new AsyncManualResetEvent();


### PR DESCRIPTION
This change will detect the existence of the SpecFlow for Visual Studio extension and prompt the user with a warning message which asks them to disable/uninstall it.

### 🤔 What's changed?

Adds a SpecFlowExtensionDetectionService which enumerates the assemblies loaded by VisualStudio and finds if any of them begin with the string "SpecFlow.VisualStudio". If so, it displays a message in a dialog box.

### ⚡️ What's your motivation? 

Since the Reqnroll for Visual Studio extension supports SpecFlow projects there is no need for both extensions to be loaded.

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)


### ♻️ Anything particular you want feedback on?

When running the test suite, there is one failing Connector test on my machine. It may just be something odd with my setup.

### 📋 Checklist:


- [X ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [X] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
