### PR TITLE
Fix up invalid github URLs 

### DIFF
--- a/Reqnroll.VisualStudio/Discovery/DiscoveryInvoker.cs
+++ b/Reqnroll.VisualStudio/Discovery/DiscoveryInvoker.cs
@@ -109,7 +109,7 @@ internal class DiscoveryInvoker
             _logger.LogWarning(
                 "The project bindings (e.g. step definitions) could not be discovered." +
                 " Navigation, step completion and other features are disabled. " + Environment.NewLine +
-                "  Please check the error message above and report to https://github.com/reqnroll/Reqnroll.VS/issues if you cannot fix.");
+                "  Please check the error message above and report to https://github.com/reqnroll/Reqnroll.VisualStudio/issues if you cannot fix.");
 
             _errorListServices.AddErrors(new[]
             {

--- a/Reqnroll.VisualStudio/UI/ViewModels/ReportErrorDialogViewModel.cs
+++ b/Reqnroll.VisualStudio/UI/ViewModels/ReportErrorDialogViewModel.cs
@@ -13,7 +13,7 @@ public class ReportErrorDialogViewModel
             This issue causes instability or blocks important features such as navigation or auto-complete.
             
             *Please help us and other Reqnroll users* by reporting this issue in our issue tracker at 
-            https://github.com/reqnroll/Reqnroll.VS/issues.
+            https://github.com/reqnroll/Reqnroll.VisualStudio/issues.
         ";
 
     internal const string INIT_ERROR = @"
@@ -21,7 +21,7 @@ public class ReportErrorDialogViewModel
             version. (The version of your Visual Studio can be found in the '*Help / About*' dialog.) 
 
             If the problem persists even after updating Visual Studio, please report the error above in our issue tracker at 
-            https://github.com/reqnroll/Reqnroll.VS/issues.
+            https://github.com/reqnroll/Reqnroll.VisualStudio/issues.
         ";
 
 #if DEBUG


### PR DESCRIPTION


### 🤔 What's changed?

Changed the URLs in a few error messages that would lead users to a 404 on the Github.com website. The corrections lead them now to https://reqnroll/Reqnoll.VisualStudio/issues


### ⚡️ What's your motivation? 

Prevent user frustration.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)


### 📋 Checklist:

None of these required, simple spelling issue.

- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
