### PR TITLE
Fix: Define Steps produces incorrect cucumber expression for step definition (#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # [vNext]
-
+* Fix: GH28: Define Steps produces incorrect regex for step definition
 ## Improvements:
 
 * Find Unused Step Definitions Command: Improved handling of Step Definitions decorated with the 'StepDefinition' attribute. If a Step Definition is used in any Given/Then/When step in a Feature file, the step will no longer show in the 'Find Unused Step Definitions' context menu. (#24)

--- a/Reqnroll.VisualStudio/Snippets/Fallback/CucumberExpressionSkeletonProvider.cs
+++ b/Reqnroll.VisualStudio/Snippets/Fallback/CucumberExpressionSkeletonProvider.cs
@@ -28,7 +28,7 @@ public class CucumberExpressionSkeletonProvider : DeveroomStepDefinitionSkeleton
 
     private string EscapeCucumberExpression(string text)
     {
-        var escapedCukeEx = Regex.Escape(text).Replace("\"", "\"\"").Replace(@"\ ", @" ");
+        var escapedCukeEx = text.Replace(@"\", @"\\").Replace(@"{", @"\{").Replace("(", @"\(").Replace("/", @"\/");
         var escapedCSharpString = escapedCukeEx.Replace(@"\", @"\\").Replace(@"""", @"\""");
         return escapedCSharpString;
     }

--- a/Reqnroll.VisualStudio/Snippets/Fallback/CucumberExpressionSkeletonProvider.cs
+++ b/Reqnroll.VisualStudio/Snippets/Fallback/CucumberExpressionSkeletonProvider.cs
@@ -28,7 +28,7 @@ public class CucumberExpressionSkeletonProvider : DeveroomStepDefinitionSkeleton
 
     private string EscapeCucumberExpression(string text)
     {
-        var escapedCukeEx = text.Replace(@"\", @"\\").Replace(@"{", @"\{").Replace("(", @"\");
+        var escapedCukeEx = Regex.Escape(text).Replace("\"", "\"\"").Replace(@"\ ", @" ");
         var escapedCSharpString = escapedCukeEx.Replace(@"\", @"\\").Replace(@"""", @"\""");
         return escapedCSharpString;
     }

--- a/Tests/Reqnroll.VisualStudio.Specs/Features/Editor/Commands/DefineStepsCommand.feature
+++ b/Tests/Reqnroll.VisualStudio.Specs/Features/Editor/Commands/DefineStepsCommand.feature
@@ -134,13 +134,13 @@ Scenario: DefineSteps command properly escapes empty brackets when using Cucumbe
 		Feature: Scenario using empty brackets
 		
 		Scenario: Client has a simple basket
-			When I call the integer.ToString() method
+			When I use (parenthesis), {curly braces} and/or \ backslash
 		"""
 	And the project is built and the initial binding discovery is performed
 	When I invoke the "Define Steps" command
 	Then the define steps dialog should be opened with the following step definition skeletons
 		| type | expression                                 |
-		| When | I call the integer\\.ToString\\(\\) method |
+		| When | I use \\(parenthesis), \\{curly braces} and\\/or \\\ backslash |
 
 Scenario: DefineSteps command properly escapes empty brackets when using Regex expressions
 	Given there is a Reqnroll project scope
@@ -149,7 +149,7 @@ Scenario: DefineSteps command properly escapes empty brackets when using Regex e
 		Feature: Scenario using empty brackets
 		
 		Scenario: Client has a simple basket
-			When I call the integer.ToString() method
+			When I use (parenthesis), {curly braces}, \ backslash, and/or . period
 		"""
 	And the reqnroll.json configuration file contains
 		"""
@@ -160,6 +160,6 @@ Scenario: DefineSteps command properly escapes empty brackets when using Regex e
 	And the project is built and the initial binding discovery is performed
 	When I invoke the "Define Steps" command
 	Then the define steps dialog should be opened with the following step definition skeletons
-		| type | expression                                 |
-		| When | I call the integer\\.ToString\\(\\) method |
+		| type | expression |
+		| When | I use \\(parenthesis\), \\{curly braces}, \\\ backslash, and/or \\. period |
 

--- a/Tests/Reqnroll.VisualStudio.Specs/Features/Editor/Commands/DefineStepsCommand.feature
+++ b/Tests/Reqnroll.VisualStudio.Specs/Features/Editor/Commands/DefineStepsCommand.feature
@@ -127,3 +127,39 @@ Scenario: DefineSteps command abides by reqnroll.json configuration for regex sk
 			| type  | expression                        |
 			| Given | the client added (.*) pcs to the basket |
 
+Scenario: DefineSteps command properly escapes empty brackets when using Cucumber expressions
+	Given there is a Reqnroll project scope
+	And the following feature file in the editor
+		"""
+		Feature: Scenario using empty brackets
+		
+		Scenario: Client has a simple basket
+			When I call the integer.ToString() method
+		"""
+	And the project is built and the initial binding discovery is performed
+	When I invoke the "Define Steps" command
+	Then the define steps dialog should be opened with the following step definition skeletons
+		| type | expression                                 |
+		| When | I call the integer\\.ToString\\(\\) method |
+
+Scenario: DefineSteps command properly escapes empty brackets when using Regex expressions
+	Given there is a Reqnroll project scope
+	And the following feature file in the editor
+		"""
+		Feature: Scenario using empty brackets
+		
+		Scenario: Client has a simple basket
+			When I call the integer.ToString() method
+		"""
+	And the reqnroll.json configuration file contains
+		"""
+		{ 
+			"trace": { "stepDefinitionSkeletonStyle": "RegexAttribute" }
+		}
+		"""
+	And the project is built and the initial binding discovery is performed
+	When I invoke the "Define Steps" command
+	Then the define steps dialog should be opened with the following step definition skeletons
+		| type | expression                                 |
+		| When | I call the integer\\.ToString\\(\\) method |
+


### PR DESCRIPTION
### 🤔 What's changed?

Modified the set of character escapes conducted within the CucumberExpressionSkeletonProvider such that the default set of characters needing escaping are escaped (such as was done within the Regex skeleton provider.

### ⚡️ What's your motivation? 

This addresses the problem identified in GH28 in which empty parentheses resulted in an improper cucumber expression.

### 🏷️ What kind of change is this?


- :bug: Bug fix (non-breaking change which fixes a defect)


### ♻️ Anything particular you want feedback on?

@gasparnagy please confirm that these character escapes won't cause other problems with Cucumber expressions and they remain compliant with Cucumber syntax and semantics.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [X ] I've changed the behaviour of the code
  - [ X] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [X ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
