### PR TITLE
Extend config file locations to match the locations searched for the reqnroll runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@
 
 * Find Unused Step Definitions Command: Improved handling of Step Definitions decorated with the 'StepDefinition' attribute. If a Step Definition is used in any Given/Then/When step in a Feature file, the step will no longer show in the 'Find Unused Step Definitions' context menu. (#24)
 * Detect existence of SpecFlow for Visual Studio extension and show a warning (#16)
+* Extend searched config file locations to match the locations searched for the reqnroll runtime
 
 ## Bug fixes:
 
 * Fix: Using the extension side-by-side with the SpecFlow for Visual Studio extension causes CompositionFailedException (#25)
 
-*Contributors of this release (in alphabetical order):* @clrudolphi, @gasparnagy, @UL-ChrisGlew
+*Contributors of this release (in alphabetical order):* @clrudolphi, @gasparnagy, @jdb0123, @UL-ChrisGlew
 
 # v2024.2.93 - 2024-06-05
 

--- a/Reqnroll.VisualStudio/ProjectSystem/Settings/ReqnrollProjectSettingsProvider.cs
+++ b/Reqnroll.VisualStudio/ProjectSystem/Settings/ReqnrollProjectSettingsProvider.cs
@@ -215,11 +215,8 @@ public class ReqnrollProjectSettingsProvider
 
         var configFilePath = GetConfigFileInPath(fileSystem, projectScope.ProjectFolder);
 
-        if (assemblyDirectory != null)
-        {
+        if (assemblyDirectory != null) 
           configFilePath ??= GetConfigFileInPath(fileSystem, assemblyDirectory);
-          configFilePath ??= GetConfigFileInPath(fileSystem, Path.Combine(assemblyDirectory, "..", ".."));
-        }
         
         return configFilePath;
     }

--- a/Reqnroll.VisualStudio/ProjectSystem/Settings/ReqnrollProjectSettingsProvider.cs
+++ b/Reqnroll.VisualStudio/ProjectSystem/Settings/ReqnrollProjectSettingsProvider.cs
@@ -224,13 +224,13 @@ public class ReqnrollProjectSettingsProvider
         return configFilePath;
     }
 
-    private static string GetConfigFileInPath(IFileSystemForVs fileSystem, string projectFolder)
+    private static string GetConfigFileInPath(IFileSystemForVs fileSystem, string folder)
     {
-      return fileSystem.GetFilePathIfExists(Path.Combine(projectFolder,
+      return fileSystem.GetFilePathIfExists(Path.Combine(folder,
                ProjectScopeDeveroomConfigurationProvider.ReqnrollJsonConfigFileName)) ??
-             fileSystem.GetFilePathIfExists(Path.Combine(projectFolder,
+             fileSystem.GetFilePathIfExists(Path.Combine(folder,
                ProjectScopeDeveroomConfigurationProvider.SpecFlowJsonConfigFileName)) ??
-             fileSystem.GetFilePathIfExists(Path.Combine(projectFolder,
+             fileSystem.GetFilePathIfExists(Path.Combine(folder,
                ProjectScopeDeveroomConfigurationProvider.SpecFlowAppConfigFileName));
     }
 }

--- a/Reqnroll.VisualStudio/ProjectSystem/Settings/ReqnrollProjectSettingsProvider.cs
+++ b/Reqnroll.VisualStudio/ProjectSystem/Settings/ReqnrollProjectSettingsProvider.cs
@@ -210,13 +210,27 @@ public class ReqnrollProjectSettingsProvider
 
     private string GetReqnrollConfigFilePath(IProjectScope projectScope)
     {
-        var projectFolder = projectScope.ProjectFolder;
         var fileSystem = projectScope.IdeScope.FileSystem;
-        return fileSystem.GetFilePathIfExists(Path.Combine(projectFolder,
-                   ProjectScopeDeveroomConfigurationProvider.ReqnrollJsonConfigFileName)) ??
-               fileSystem.GetFilePathIfExists(Path.Combine(projectFolder,
-                   ProjectScopeDeveroomConfigurationProvider.SpecFlowJsonConfigFileName)) ??
-               fileSystem.GetFilePathIfExists(Path.Combine(projectFolder,
-                   ProjectScopeDeveroomConfigurationProvider.SpecFlowAppConfigFileName));
+        var assemblyDirectory = Path.GetDirectoryName(projectScope.OutputAssemblyPath);
+
+        var configFilePath = GetConfigFileInPath(fileSystem, projectScope.ProjectFolder);
+
+        if (assemblyDirectory != null)
+        {
+          configFilePath ??= GetConfigFileInPath(fileSystem, assemblyDirectory);
+          configFilePath ??= GetConfigFileInPath(fileSystem, Path.Combine(assemblyDirectory, "..", ".."));
+        }
+        
+        return configFilePath;
+    }
+
+    private static string GetConfigFileInPath(IFileSystemForVs fileSystem, string projectFolder)
+    {
+      return fileSystem.GetFilePathIfExists(Path.Combine(projectFolder,
+               ProjectScopeDeveroomConfigurationProvider.ReqnrollJsonConfigFileName)) ??
+             fileSystem.GetFilePathIfExists(Path.Combine(projectFolder,
+               ProjectScopeDeveroomConfigurationProvider.SpecFlowJsonConfigFileName)) ??
+             fileSystem.GetFilePathIfExists(Path.Combine(projectFolder,
+               ProjectScopeDeveroomConfigurationProvider.SpecFlowAppConfigFileName));
     }
 }


### PR DESCRIPTION
### 🤔 What's changed?

Extension now searches for json config file in the following locations:
* Project folder (already the case before)
* Assembly directory
* Two folders above assembly directory

### ⚡️ What's your motivation? 

#17 
The reqnroll runtime searched these locations.
This meant that it was possible to have a correctly compiling and running build, but the extension would not be able to find the steps in the feature files.

### 🏷️ What kind of change is this?


- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

As far as I can see there are currently no test covering this behaviour.
Is this actually the case?

### 📋 Checklist:


- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.

