### PR TITLE
Fix #300 ProjectTemplate creates reference to Reqnroll.MsTest v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## Bug fixes:
 
 * Bug Fix: Fix 'Reqnroll Extension v2024.3.152 does not work on Visual Studio 17.11.4 (#37)' by including missing assemblies.
-
-*Contributors of this release (in alphabetical order): @UL-ChrisGlew* 
+* Bug Fix: Visual Studio 2022 extension "Add New Project" adds dependency for Reqnroll.MsTest 1.0.0 #300
+*Contributors of this release (in alphabetical order): @clrudolphi, @UL-ChrisGlew* 
 
 # v2024.4.154 - 2024-09-18
 

--- a/Reqnroll.VisualStudio.ProjectTemplate/ProjectTemplate.csproj
+++ b/Reqnroll.VisualStudio.ProjectTemplate/ProjectTemplate.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Reqnroll.NUnit" Version="2.0.2" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />$endif$$if$ ('$unittestframework$' == 'MSTest')
-    <PackageReference Include="Reqnroll.MsTest" Version="2.*" />
+    <PackageReference Include="Reqnroll.MsTest" Version="2.0.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />$endif$$if$ ('$fluentassertionsincluded$' == 'True')
     <PackageReference Include="FluentAssertions" Version="6.12.0" />$endif$

--- a/Reqnroll.VisualStudio.ProjectTemplate/ProjectTemplate.csproj
+++ b/Reqnroll.VisualStudio.ProjectTemplate/ProjectTemplate.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Reqnroll.NUnit" Version="2.0.2" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />$endif$$if$ ('$unittestframework$' == 'MSTest')
-    <PackageReference Include="Reqnroll.MsTest" Version="1.0.0" />
+    <PackageReference Include="Reqnroll.MsTest" Version="2.*" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />$endif$$if$ ('$fluentassertionsincluded$' == 'True')
     <PackageReference Include="FluentAssertions" Version="6.12.0" />$endif$


### PR DESCRIPTION
### What's Changed?
Fix #300 Modified the ProjectTemplate\ProjectTemplate.csproj to have a version range reference to Reqnroll.MsTest of version 2.*

### ⚡️ What's your motivation? 

New projects created with the Reqnroll new project wizard should start with references to the latest version of Reqnroll.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)


### ♻️ Anything particular you want feedback on?

Should the same changes be made to the references created for Reqnroll.NUnit and xUnit?

### 📋 Checklist:

- [ X] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ X] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.


