### PR TITLE
Fix: Error message box when creating feature file with space in its name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ## Bug fixes:
 
-*Contributors of this release (in alphabetical order):* 
+* Fix: Error message box when creating feature file with space in its name (#50)
+
+*Contributors of this release (in alphabetical order):* @gasparnagy
 
 # v2024.7.204 - 2024-11-20
 

--- a/Reqnroll.VisualStudio.Package/Wizards/Infrastructure/VsSimulatedItemAddProjectScopeWizard.cs
+++ b/Reqnroll.VisualStudio.Package/Wizards/Infrastructure/VsSimulatedItemAddProjectScopeWizard.cs
@@ -92,7 +92,7 @@ public abstract class VsSimulatedItemAddProjectScopeWizard<TWizard> : VsProjectS
             if (projectItem != null)
             {
                 //projectItem.Open();
-                project.DTE.ExecuteCommand("File.OpenFile", targetFile);
+                project.DTE.ExecuteCommand("File.OpenFile", $"\"{targetFile}\"");
                 logger.LogVerbose($"File opened: {targetFile}");
             }
         }


### PR DESCRIPTION
### 🤔 What's changed?

Fix: Error message box when creating feature file with space in its name

The "Add feature file" wizard has a special handling of feature files: it bypasses the standard VS "add" functionality and creates the file directly on disk. To simulate the VS "add" behavior it also opens the file after the add wizard has been finished. This is performed using `DTE.ExecuteCommand("File.OpenFile", <filepath>)` command that does not seem to handle spaces in file name by default, you need to wrap the file name with double quotes. This wrapping has been added now.

### ⚡️ What's your motivation? 

Fixes #50 

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

Can only be tested manually. Tests have been performed.

### 📋 Checklist:

- [x] I've changed the behaviour of the code
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
