### PR TITLE
StepDefinitionSampler: do not convert options list parameter to [string]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## Improvements:
 
+* Step previews: do not convert options list parameter, e.g. '(option1|option2|option3)', to [string]
+
 ## Bug fixes:
 
 * Fix: Error message box when creating feature file with space in its name (#50)
 
-*Contributors of this release (in alphabetical order):* @gasparnagy
+*Contributors of this release (in alphabetical order):* @gasparnagy, @RikvanSpreuwel
 
 # v2024.7.204 - 2024-11-20
 

--- a/Reqnroll.VisualStudio/Editor/Completions/StepDefinitionSampler.cs
+++ b/Reqnroll.VisualStudio/Editor/Completions/StepDefinitionSampler.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Linq;
-
 namespace Reqnroll.VisualStudio.Editor.Completions;
 
 public class StepDefinitionSampler
@@ -23,16 +20,29 @@ public class StepDefinitionSampler
             completionTextBuilder.Append(GetUnescapedText(analyzedStepDefinitionExpression.Parts[i]));
             if (i < analyzedStepDefinitionExpression.Parts.Length - 1)
             {
-                completionTextBuilder.Append("[");
-                completionTextBuilder.Append(GetPlaceHolderText(stepDefinitionBinding, i / 2));
-                completionTextBuilder.Append("]");
+                if (ParameterIsListOfOptions(GetUnescapedText(analyzedStepDefinitionExpression.Parts[i + 1])))
+                    completionTextBuilder.Append(GetUnescapedText(analyzedStepDefinitionExpression.Parts[i + 1]));
+                else
+                {
+                    completionTextBuilder.Append("[");
+                    completionTextBuilder.Append(GetPlaceHolderText(stepDefinitionBinding, i / 2));
+                    completionTextBuilder.Append("]");
+                }
             }
         }
 
         return completionTextBuilder.ToString();
     }
 
-    private string GetUnescapedText(AnalyzedStepDefinitionExpressionPart part)
+
+  private bool ParameterIsListOfOptions(string parameter)
+  {
+    var regex = new Regex(@"^\(\s*[a-zA-Z0-9 ]+(?:\s*\|\s*[a-zA-Z0-9 ]+)*\s*\)$");
+    return regex.IsMatch(parameter);
+  }
+
+
+  private string GetUnescapedText(AnalyzedStepDefinitionExpressionPart part)
     {
         if (part is AnalyzedStepDefinitionExpressionSimpleTextPart simpleTextPart)
             return simpleTextPart.UnescapedText;

--- a/Tests/Reqnroll.VisualStudio.Tests/Editor/Completions/StepDefinitionSamplerTests.cs
+++ b/Tests/Reqnroll.VisualStudio.Tests/Editor/Completions/StepDefinitionSamplerTests.cs
@@ -1,6 +1,4 @@
 #nullable disable
-using System;
-using System.Linq;
 using Reqnroll.VisualStudio.Editor.Completions;
 
 namespace Reqnroll.VisualStudio.Tests.Editor.Completions;
@@ -9,7 +7,7 @@ public class StepDefinitionSamplerTests
 {
     private ProjectStepDefinitionBinding CreateStepDefinitionBinding(string regex, params string[] parameterTypes)
     {
-        parameterTypes = parameterTypes ?? new string[0];
+        parameterTypes ??= Array.Empty<string>();
         return new ProjectStepDefinitionBinding(ScenarioBlock.Given, new Regex("^" + regex + "$"), null,
             new ProjectBindingImplementation("M1", parameterTypes, null));
     }
@@ -89,5 +87,21 @@ public class StepDefinitionSamplerTests
         var result = sut.GetStepDefinitionSample(CreateStepDefinitionBinding(regex, "System.Int32"));
 
         result.Should().Be(regex);
+    }
+
+    [Theory]
+    [InlineData("(.*) is entered into the (very basic|standard|scientific) calculator", 
+      "[int] is entered into the (very basic|standard|scientific) calculator", 
+      "System.Int32", "System.String")]
+    [InlineData("(.*) is entered into the ( 1st| 2nd | 3 rd |4th) calculator and saved with name ([^']*)",
+      "[int] is entered into the ( 1st| 2nd | 3 rd |4th) calculator and saved with name [string]", 
+      "System.Int32", "System.String", "System.String")]
+    public void Does_not_replace_choice_parameters(string regex, string expectedResult, params string[] paramType)
+    {
+      var sut = new StepDefinitionSampler();
+
+      var result = sut.GetStepDefinitionSample(CreateStepDefinitionBinding(regex, paramType));
+
+      result.Should().Be(expectedResult);
     }
 }


### PR DESCRIPTION
### 🤔 What's changed?

Step previews (in StepDefinitionSampler.cs): do not convert options list parameter, e.g. '(option1|option2|option3)', to [string]

### ⚡️ What's your motivation? 

See: https://github.com/orgs/reqnroll/discussions/351

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

- [X] I've changed the behaviour of the code
  - [X] I have added/updated tests to cover my changes.
- [X] Users should know about my change
  - [X] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.
