### PR TITLE
Hide FluentAssertions from new project wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Improvements:
 
+* Suggestion for adding [FluentAssertions](https://github.com/fluentassertions/fluentassertions) on the new project wizard screen has been removed to avoid confusions, because FluentAssertion does not offer free use for commercial projects anymore. (#60)
+
 ## Bug fixes:
 
 * Fix: Error message box when creating feature file with space in its name (#50)

--- a/Reqnroll.VisualStudio.UI/Dialogs/AddNewReqnrollProjectDialog.xaml
+++ b/Reqnroll.VisualStudio.UI/Dialogs/AddNewReqnrollProjectDialog.xaml
@@ -251,7 +251,7 @@
 							          SelectionChanged="TestFramework_SelectionChanged" />
 						</StackPanel>
 
-						<StackPanel Grid.Row="2" Grid.Column="0">
+						<StackPanel Grid.Row="2" Grid.Column="0" Visibility="Collapsed">
 							<CheckBox x:Name="FluentAssertionsCheckBox" Content="Add FluentAssertions library"
 							          IsChecked="{Binding FluentAssertionsIncluded}" />
 						</StackPanel>

--- a/Reqnroll.VisualStudio/UI/ViewModels/AddNewReqnrollProjectViewModel.cs
+++ b/Reqnroll.VisualStudio/UI/ViewModels/AddNewReqnrollProjectViewModel.cs
@@ -11,7 +11,7 @@ public class AddNewReqnrollProjectViewModel : INotifyPropertyChanged
     {
         DotNetFramework = Net8,
         UnitTestFramework = MsTest,
-        FluentAssertionsIncluded = true
+        FluentAssertionsIncluded = false
     };
 #endif
     private string _dotNetFramework = Net8;
@@ -27,7 +27,10 @@ public class AddNewReqnrollProjectViewModel : INotifyPropertyChanged
     }
 
     public string UnitTestFramework { get; set; } = MsTest;
-    public bool FluentAssertionsIncluded { get; set; } = true;
+    // FluentAssertions suggestion is temporarily hidden from the UI as it is not free for commercial use anymore. 
+    // See https://xceed.com/fluent-assertions-faq/
+    // Maybe we could consider suggesting https://github.com/shouldly/shouldly instead.
+    public bool FluentAssertionsIncluded { get; set; } = false;
     public ObservableCollection<string> TestFrameworks { get; } = new(new List<string> { "MSTest", "NUnit", "xUnit" });
 
     public event PropertyChangedEventHandler PropertyChanged;


### PR DESCRIPTION
### 🤔 What's changed?

Suggestion for adding [FluentAssertions](https://github.com/fluentassertions/fluentassertions) on the new project wizard screen has been removed to avoid confusions, because FluentAssertion does not offer free use for commercial projects anymore.

The code is only hidden, not removed yet. Maybe we could consider suggesting https://github.com/shouldly/shouldly instead later.

### ⚡️ What's your motivation? 

See https://xceed.com/fluent-assertions-faq/

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behavior)

### ♻️ Anything particular you want feedback on?


### 📋 Checklist:

- [x] I've changed the behaviour of the code
- [x] Users should know about my change
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
