### PR TITLE
Change default .NET to be used for discover to .NET 8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Bug fixes:
 
 * Fix: Error message box when creating feature file with space in its name (#50)
+* Fix: Error during discovery of .NET 4 projects when .NET 6.0 is not installed (#53)
 
 *Contributors of this release (in alphabetical order):* @gasparnagy, @RikvanSpreuwel
 

--- a/Reqnroll.VisualStudio/Connectors/GenericOutProcReqnrollConnector.cs
+++ b/Reqnroll.VisualStudio/Connectors/GenericOutProcReqnrollConnector.cs
@@ -33,16 +33,24 @@ public class GenericOutProcReqnrollConnector : OutProcReqnrollConnector
     protected override string GetConnectorPath(List<string> arguments)
     {
         var connector = _projectSettings.IsSpecFlowProject ? 
-            SpecFlowConnectorNet60 : ConnectorNet60;
+            SpecFlowConnectorNet80 : ConnectorNet80;
+
         if (_targetFrameworkMoniker.IsNetCore && _targetFrameworkMoniker.HasVersion &&
-            _targetFrameworkMoniker.Version.Major >= 7)
+            _targetFrameworkMoniker.Version.Major == 6)
+        {
+            connector = _projectSettings.IsSpecFlowProject ?
+                SpecFlowConnectorNet60 : ConnectorNet60;
+        }
+
+        if (_targetFrameworkMoniker.IsNetCore && _targetFrameworkMoniker.HasVersion &&
+            _targetFrameworkMoniker.Version.Major == 7)
         {
             connector = _projectSettings.IsSpecFlowProject ?
                 SpecFlowConnectorNet70 : ConnectorNet70;
         }
 
         if (_targetFrameworkMoniker.IsNetCore && _targetFrameworkMoniker.HasVersion &&
-            _targetFrameworkMoniker.Version.Major >= 8)
+            _targetFrameworkMoniker.Version.Major == 8)
         {
             connector = _projectSettings.IsSpecFlowProject ?
                 SpecFlowConnectorNet80 : ConnectorNet80;


### PR DESCRIPTION
### 🤔 What's changed?

Changed the discoverer to be used for .NET Framework from the one runs on .NET 6.0 to .NET 8.0. 

### ⚡️ What's your motivation? 

Fix: Error during discovery of .NET 4 projects when .NET 6.0 is not installed (#53)

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

Note that all supported VS 2022 versions (currently 17.8+) installs .NET 8.0 by default. 

### 📋 Checklist:

- [x] I've changed the behaviour of the code
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
