### PR TITLE
Fix .NET 4.6.2 Discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 * Fix: Error message box when creating feature file with space in its name (#50)
 * Fix: Error during discovery of .NET 4 projects when .NET 6.0 is not installed (#53)
+* Fix: Bindings cannot be discovered for .NET 4.6.2 projects (#62)
 
 *Contributors of this release (in alphabetical order):* @gasparnagy, @RikvanSpreuwel
 

--- a/Connectors/Reqnroll.VisualStudio.ReqnrollConnector.Generic/AssemblyLoading/RuntimeCompositeCompilationAssemblyResolver.cs
+++ b/Connectors/Reqnroll.VisualStudio.ReqnrollConnector.Generic/AssemblyLoading/RuntimeCompositeCompilationAssemblyResolver.cs
@@ -11,15 +11,22 @@ public class RuntimeCompositeCompilationAssemblyResolver : ICompilationAssemblyR
         _log = log;
     }
 
-    public bool TryResolveAssemblyPaths(CompilationLibrary library, List<string> assemblies)
+    public bool TryResolveAssemblyPaths(CompilationLibrary library, List<string>? assemblies)
     {
         foreach (ICompilationAssemblyResolver resolver in _resolvers)
             try
             {
                 if (resolver.TryResolveAssemblyPaths(library, assemblies) &&
+                    assemblies != null &&
                     assemblies.Any(a => !IsRefsPath(a)))
                 {
-                    var resolveAssemblyPath = assemblies.FirstOrDefault(a => !IsRefsPath(a));
+                    var resolveAssemblyPath = assemblies.First(a => !IsRefsPath(a));
+                    if ("System.Runtime.dll".Equals(Path.GetFileName(resolveAssemblyPath), StringComparison.OrdinalIgnoreCase))
+                    {
+                        _log.Info($"Skipping {resolveAssemblyPath} ({resolver})");
+                        assemblies.Remove(resolveAssemblyPath);
+                        return false;
+                    }
                     _log.Info($"Resolved with {resolver} from {resolveAssemblyPath}");
                     return true;
                 }

--- a/Connectors/SpecFlow.VisualStudio.SpecFlowConnector.Generic/AssemblyLoading/RuntimeCompositeCompilationAssemblyResolver.cs
+++ b/Connectors/SpecFlow.VisualStudio.SpecFlowConnector.Generic/AssemblyLoading/RuntimeCompositeCompilationAssemblyResolver.cs
@@ -11,15 +11,22 @@ public class RuntimeCompositeCompilationAssemblyResolver : ICompilationAssemblyR
         _log = log;
     }
 
-    public bool TryResolveAssemblyPaths(CompilationLibrary library, List<string> assemblies)
+    public bool TryResolveAssemblyPaths(CompilationLibrary library, List<string>? assemblies)
     {
         foreach (ICompilationAssemblyResolver resolver in _resolvers)
             try
             {
                 if (resolver.TryResolveAssemblyPaths(library, assemblies) &&
+                    assemblies != null &&
                     assemblies.Any(a => !IsRefsPath(a)))
                 {
-                    var resolveAssemblyPath = assemblies.FirstOrDefault(a => !IsRefsPath(a));
+                    var resolveAssemblyPath = assemblies.First(a => !IsRefsPath(a));
+                    if ("System.Runtime.dll".Equals(Path.GetFileName(resolveAssemblyPath), StringComparison.OrdinalIgnoreCase))
+                    {
+                        _log.Info($"Skipping {resolveAssemblyPath} ({resolver})");
+                        assemblies.Remove(resolveAssemblyPath);
+                        return false;
+                    }
                     _log.Info($"Resolved with {resolver} from {resolveAssemblyPath}");
                     return true;
                 }


### PR DESCRIPTION
### 🤔 What's changed?

Fixed binding discovery for .NET 4.6.2 by not allowing to resolve the `System.Runtime.dll` from the project folder.

### ⚡️ What's your motivation? 

Fix .NET 4.6.2 Discovery

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :book: Documentation (improvements without changing code)
- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)
- :zap: New feature (non-breaking change which adds new behaviour)
- :boom: Breaking change (incompatible changes to the API)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I've changed the behaviour of the code
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
