### PR TITLE
Modified the heuristic test used by the FindStepDefinitionUsagesCommand #68

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ## Bug fixes:
 
 *Contributors of this release (in alphabetical order):* @jdb0123
-
+* Bug Fix: Improved heuristics used to identify whether to display the 'FindStepDefinitionUsages' and 'FindUnusedStepDefinitionUsages' commands (#68)
 # v2024.8.234 - 2025-01-22
 
 ## Improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Bug fixes:
 
-*Contributors of this release (in alphabetical order):* @jdb0123
+*Contributors of this release (in alphabetical order):* @jdb0123, @clrudolphi
 * Bug Fix: Improved heuristics used to identify whether to display the 'FindStepDefinitionUsages' and 'FindUnusedStepDefinitionUsages' commands (#68)
 # v2024.8.234 - 2025-01-22
 

--- a/Reqnroll.VisualStudio/Editor/Commands/FindUnusedStepDefinitionsCommand.cs
+++ b/Reqnroll.VisualStudio/Editor/Commands/FindUnusedStepDefinitionsCommand.cs
@@ -30,7 +30,7 @@
         {
             var status = base.QueryStatus(textView, commandKey);
 
-            var heuristicTest = textView.TextBuffer.CurrentSnapshot.GetText().Contains("Reqnroll") || textView.TextBuffer.CurrentSnapshot.GetText().Contains("SpecFlow");
+            var heuristicTest = FindStepDefinitionUsagesCommand.IsBufferContainsReqnrollBindingFileContent(textView.TextBuffer.CurrentSnapshot.GetText());
 
             if (status != DeveroomEditorCommandStatus.NotSupported)
                 // very basic heuristic: if the word "Reqnroll" or "SpecFlow" is in the content of the file, it might be a binding class


### PR DESCRIPTION
Modified the heuristic test used by the FindStepDefinitionUsagesCommand to look for any of the names of the binding attributes instead of looking only for the word Reqnroll.

Same change applied to the FindUnusedStepDefinitionsCommand.



### 🤔 What's changed?

When the `using Reqnroll;` is moved to the ImplicitUsings.cs file as a global using, the source text of binding classes no longer has the word Reqnroll present in the text. This was used as a heuristic by the FindStepDefinitionUsages command as an indicator that the source file was a Reqnroll binding class file and controlled whether the command for the FindStepDefinition command was presented to the user on the right-click context menu.

This change enhances that heuristic check to look for the word Reqnroll, or SpecFlow, or any of the names of the primary attributes used by binding classes (Binding, Given, When, Then).

With this change, the menu now appears without the using Reqnoll; statement in the file:
![image](https://github.com/user-attachments/assets/2dff9be5-7eb9-4c80-b410-3d44329f95bc)

### ⚡️ What's your motivation? 

Fixes #68 

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

Is the list of keywords complete?

### 📋 Checklist:

I have not added a test for this (but have included a screenshot indicating that it works).

- [X] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.
