### PR TITLE
Fix flaky tests & updated ApprovalTests

### DIFF
--- a/Tests/Connector/Reqnroll.VisualStudio.ReqnrollConnector.Tests/Reqnroll.VisualStudio.ReqnrollConnector.Tests.csproj
+++ b/Tests/Connector/Reqnroll.VisualStudio.ReqnrollConnector.Tests/Reqnroll.VisualStudio.ReqnrollConnector.Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ApprovalTests" Version="5.9.0" /> <!-- cannot upgrade to 6.0 because of test execution issues -->
+    <PackageReference Include="ApprovalTests" Version="6.0.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />

--- a/Tests/Reqnroll.VisualStudio.Tests/Diagnostics/LoggingTests.cs
+++ b/Tests/Reqnroll.VisualStudio.Tests/Diagnostics/LoggingTests.cs
@@ -18,7 +18,7 @@ public class LoggingTests
         var message = new LogMessage(logLevel, "msg", nameof(MessageIsLogged));
         logger.Log(message);
 
-        var maxWaitTime = TimeSpan.FromMilliseconds(100);
+        var maxWaitTime = TimeSpan.FromSeconds(2);
         var sw = Stopwatch.StartNew();
         while (!LogFileContains(fileSystem, logger, "msg") && sw.Elapsed < maxWaitTime)
         {

--- a/Tests/Reqnroll.VisualStudio.Tests/Diagnostics/LoggingTests.cs
+++ b/Tests/Reqnroll.VisualStudio.Tests/Diagnostics/LoggingTests.cs
@@ -2,7 +2,7 @@ namespace Reqnroll.VisualStudio.Tests.Diagnostics;
 
 public class LoggingTests
 {
-    [SkippableTheory(Skip = "Flaky, see https://github.com/reqnroll/Reqnroll.VisualStudio/issues/40 @quarantine")]
+    [Theory]
     [InlineData(TraceLevel.Verbose)]
     [InlineData(TraceLevel.Info)]
     [InlineData(TraceLevel.Warning)]
@@ -18,16 +18,21 @@ public class LoggingTests
         var message = new LogMessage(logLevel, "msg", nameof(MessageIsLogged));
         logger.Log(message);
 
+        var maxWaitTime = TimeSpan.FromMilliseconds(100);
         var sw = Stopwatch.StartNew();
-        while (!fileSystem.File.ReadAllText(logger.LogFilePath).Contains("msg") &&
-               sw.Elapsed < TimeSpan.FromMilliseconds(10))
+        while (!LogFileContains(fileSystem, logger, "msg") && sw.Elapsed < maxWaitTime)
+        {
             Thread.Sleep(10);
+        }
 
         //assert
         fileSystem.File.Exists(logger.LogFilePath).Should().BeTrue("the log should be written quickly");
-        fileSystem.File.ReadAllText(logger.LogFilePath).Should().Contain(
+        string loggedText = fileSystem.File.ReadAllText(logger.LogFilePath);
+        loggedText.Should().Contain(
             $"{message.TimeStamp:yyyy-MM-ddTHH\\:mm\\:ss.fffzzz}, {message.Level}@{message.ManagedThreadId}, {message.CallerMethod}: {message.Message}");
     }
+
+    private static bool LogFileContains(MockFileSystemForVs fileSystem, AsynchronousFileLogger logger, string message) => fileSystem.File.Exists(logger.LogFilePath) && fileSystem.File.ReadAllText(logger.LogFilePath).Contains(message);
 
     private void Warmup(AsynchronousFileLogger logger, IFileSystemForVs fileSystem)
     {

--- a/Tests/Reqnroll.VisualStudio.Tests/Diagnostics/LoggingTests.cs
+++ b/Tests/Reqnroll.VisualStudio.Tests/Diagnostics/LoggingTests.cs
@@ -1,5 +1,6 @@
 namespace Reqnroll.VisualStudio.Tests.Diagnostics;
 
+[Collection(NonParallelTestCollectionDefinition.Name)]
 public class LoggingTests
 {
     [Theory]

--- a/Tests/Reqnroll.VisualStudio.Tests/Diagnostics/NonParallelTestCollectionDefinition.cs
+++ b/Tests/Reqnroll.VisualStudio.Tests/Diagnostics/NonParallelTestCollectionDefinition.cs
@@ -3,5 +3,5 @@ namespace Reqnroll.VisualStudio.Tests.Diagnostics;
 [CollectionDefinition(Name, DisableParallelization = true)]
 public class NonParallelTestCollectionDefinition
 {
-    public const string Name = "NonParallelTestCollection";
+    internal const string Name = "NonParallelTestCollection";
 }

--- a/Tests/Reqnroll.VisualStudio.Tests/Diagnostics/NonParallelTestCollectionDefinition.cs
+++ b/Tests/Reqnroll.VisualStudio.Tests/Diagnostics/NonParallelTestCollectionDefinition.cs
@@ -1,0 +1,7 @@
+namespace Reqnroll.VisualStudio.Tests.Diagnostics;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public class NonParallelTestCollectionDefinition
+{
+    public const string Name = "NonParallelTestCollection";
+}

--- a/Tests/Reqnroll.VisualStudio.Tests/Discovery/NonParallelTestCollectionDefinition.cs
+++ b/Tests/Reqnroll.VisualStudio.Tests/Discovery/NonParallelTestCollectionDefinition.cs
@@ -1,0 +1,7 @@
+namespace Reqnroll.VisualStudio.Tests.Discovery;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public class NonParallelTestCollectionDefinition
+{
+    internal const string Name = "NonParallelTestCollection";
+}

--- a/Tests/Reqnroll.VisualStudio.Tests/Discovery/ProjectBindingRegistryCacheTests.cs
+++ b/Tests/Reqnroll.VisualStudio.Tests/Discovery/ProjectBindingRegistryCacheTests.cs
@@ -1,7 +1,12 @@
 namespace Reqnroll.VisualStudio.Tests.Discovery;
 
+[CollectionDefinition(Name, DisableParallelization = true)]
+public class NonParallelTestCollectionDefinition
+{
+    internal const string Name = "NonParallelTestCollection";
+}
 
-
+[Collection(NonParallelTestCollectionDefinition.Name)]
 public class ProjectBindingRegistryCacheTests
 {
     private readonly ITestOutputHelper _testOutputHelper;

--- a/Tests/Reqnroll.VisualStudio.Tests/Discovery/ProjectBindingRegistryCacheTests.cs
+++ b/Tests/Reqnroll.VisualStudio.Tests/Discovery/ProjectBindingRegistryCacheTests.cs
@@ -1,11 +1,5 @@
 namespace Reqnroll.VisualStudio.Tests.Discovery;
 
-[CollectionDefinition(Name, DisableParallelization = true)]
-public class NonParallelTestCollectionDefinition
-{
-    internal const string Name = "NonParallelTestCollection";
-}
-
 [Collection(NonParallelTestCollectionDefinition.Name)]
 public class ProjectBindingRegistryCacheTests
 {

--- a/Tests/Reqnroll.VisualStudio.Tests/Discovery/ProjectBindingRegistryCacheTests.cs
+++ b/Tests/Reqnroll.VisualStudio.Tests/Discovery/ProjectBindingRegistryCacheTests.cs
@@ -1,5 +1,7 @@
 namespace Reqnroll.VisualStudio.Tests.Discovery;
 
+
+
 public class ProjectBindingRegistryCacheTests
 {
     private readonly ITestOutputHelper _testOutputHelper;

--- a/Tests/Reqnroll.VisualStudio.Tests/Reqnroll.VisualStudio.Tests.csproj
+++ b/Tests/Reqnroll.VisualStudio.Tests/Reqnroll.VisualStudio.Tests.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ApprovalTests" Version="5.9.0" /> <!-- cannot upgrade to 6.0 because of test execution issues -->
+    <PackageReference Include="ApprovalTests" Version="6.0.0" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="21.0.29" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="FluentAssertions" Version="6.12.1" />


### PR DESCRIPTION
<!---
Thanks for helping to make Reqnroll better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻

You can delete these comment sections as you process them.
-->

### 🤔 What's changed?

- Update approvaltests
- Fix flaky logger tests, fixes #40 
- Fix flaky test ProjectBindingRegistryCacheTests

In detail:
- I added some more max time to the logger checks and I improved the check while waiting (saves some exceptions)
- There are many other tests which do logging, so I made the logger tests not running with those other tests and non in parallel
- ProjectBindingRegistryCacheTests where also flaky for me, so did this also for this test class


### ⚡️ What's your motivation? 
fixes #40 
<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)


### ♻️ Anything particular you want feedback on?
Should I apply this to more tests which are flaky?
<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->



----

