### PR TITLE
Fix flaky ParallelUpdate test

### DIFF
--- a/Tests/Reqnroll.VisualStudio.Tests/Discovery/ProjectBindingRegistryCacheTests.cs
+++ b/Tests/Reqnroll.VisualStudio.Tests/Discovery/ProjectBindingRegistryCacheTests.cs
@@ -87,7 +87,7 @@ public class ProjectBindingRegistryCacheTests
         var oldVersions = new ConcurrentQueue<int>();
         var initialRegistry = new ProjectBindingRegistry(Array.Empty<ProjectStepDefinitionBinding>(), Array.Empty<ProjectHookBinding>(), 123456);
 
-        var timeout = TimeSpan.FromSeconds(20);
+        var timeout = TimeSpan.FromSeconds(60);
         using var cts = new CancellationTokenSource(timeout);
         int i = 0;
         var taskCreationOptions = TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach |

--- a/Tests/Reqnroll.VisualStudio.Tests/Discovery/ProjectBindingRegistryCacheTests.cs
+++ b/Tests/Reqnroll.VisualStudio.Tests/Discovery/ProjectBindingRegistryCacheTests.cs
@@ -75,9 +75,10 @@ public class ProjectBindingRegistryCacheTests
         var start = DateTimeOffset.UtcNow;
         var ideScope = new Mock<IIdeScope>(MockBehavior.Strict);
         var stubLogger = new StubLogger();
-        var logger = new DeveroomCompositeLogger();
-
-        logger.Add(stubLogger);
+        var logger = new DeveroomCompositeLogger
+        {
+            stubLogger
+        };
 
         ideScope.SetupGet(s => s.Logger).Returns(logger);
         ideScope.Setup(s => s.CalculateSourceLocationTrackingPositions(It.IsAny<IEnumerable<SourceLocation>>()));
@@ -124,8 +125,6 @@ public class ProjectBindingRegistryCacheTests
         var cachedRegistry = projectBindingRegistryCache.Value;
         try
         {
-
-
             var registry = await projectBindingRegistryCache.GetLatest();
 #pragma warning restore
             registry.Version.Should()

--- a/Tests/Reqnroll.VisualStudio.Tests/Discovery/ProjectBindingRegistryCacheTests.cs
+++ b/Tests/Reqnroll.VisualStudio.Tests/Discovery/ProjectBindingRegistryCacheTests.cs
@@ -76,7 +76,7 @@ public class ProjectBindingRegistryCacheTests
         var ideScope = new Mock<IIdeScope>(MockBehavior.Strict);
         var stubLogger = new StubLogger();
         var logger = new DeveroomCompositeLogger();
-        logger.Add(new DeveroomXUnitLogger(_testOutputHelper));
+       // logger.Add(new DeveroomXUnitLogger(_testOutputHelper));
         logger.Add(stubLogger);
 
         ideScope.SetupGet(s => s.Logger).Returns(logger);

--- a/Tests/Reqnroll.VisualStudio.Tests/Discovery/ProjectBindingRegistryCacheTests.cs
+++ b/Tests/Reqnroll.VisualStudio.Tests/Discovery/ProjectBindingRegistryCacheTests.cs
@@ -76,7 +76,7 @@ public class ProjectBindingRegistryCacheTests
         var ideScope = new Mock<IIdeScope>(MockBehavior.Strict);
         var stubLogger = new StubLogger();
         var logger = new DeveroomCompositeLogger();
-       // logger.Add(new DeveroomXUnitLogger(_testOutputHelper));
+       
         logger.Add(stubLogger);
 
         ideScope.SetupGet(s => s.Logger).Returns(logger);
@@ -87,7 +87,7 @@ public class ProjectBindingRegistryCacheTests
         var oldVersions = new ConcurrentQueue<int>();
         var initialRegistry = new ProjectBindingRegistry(Array.Empty<ProjectStepDefinitionBinding>(), Array.Empty<ProjectHookBinding>(), 123456);
 
-        var timeout = TimeSpan.FromSeconds(60);
+        var timeout = TimeSpan.FromSeconds(20);
         using var cts = new CancellationTokenSource(timeout);
         int i = 0;
         var taskCreationOptions = TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach |


### PR DESCRIPTION
### 🤔 What's changed?

Improved the parallelUpdate test as it was very flaky

- Removed logging to testoutput, only log to testoutput if the test fails
- Made the task/threads async so there is less pressure on system
- I did ~100 test runs locally with the last change, but keep in mind this test is more flaky if all the tests are running


### ⚡️ What's your motivation? 
Fixes https://github.com/reqnroll/Reqnroll.VisualStudio/issues/78


### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->


- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

Is this test really use full?

It spins 1-1000 tasks and check for "in 2 iteration" in the logs and then cancels the task creation.
Maybe merge this PR first to get things stable


