### PR TITLE
Allow defining steps using /

### DIFF
--- a/Reqnroll.VisualStudio/Snippets/Fallback/RegexStepDefinitionSkeletonProvider.cs
+++ b/Reqnroll.VisualStudio/Snippets/Fallback/RegexStepDefinitionSkeletonProvider.cs
@@ -23,7 +23,10 @@ public class RegexStepDefinitionSkeletonProvider : DeveroomStepDefinitionSkeleto
         return result.ToString();
     }
 
-    private static string EscapeRegex(string text) => Regex.Escape(text).Replace("\"", "\"\"").Replace("\\ ", " ");
+    private static string EscapeRegex(string text) => Regex.Escape(text)
+        .Replace("\"", "\"\"")
+        .Replace("\\ ", " ")
+        .Replace("/", @"\/");
 
     protected override IStepTextAnalyzer CreateStepTextAnalyzer() => new RegexExpressionStepTextAnalyzer();
 }

--- a/Tests/Reqnroll.VisualStudio.Specs/Features/Editor/Commands/DefineStepsCommand.feature
+++ b/Tests/Reqnroll.VisualStudio.Specs/Features/Editor/Commands/DefineStepsCommand.feature
@@ -149,7 +149,7 @@ Scenario: DefineSteps command properly escapes empty brackets when using Regex e
 		Feature: Scenario using empty brackets
 		
 		Scenario: Client has a simple basket
-			When I use (parenthesis), {curly braces}, \ backslash, and/or . period
+			When I use (parenthesis), {curly braces}, \ backslash, / forwardslash, or . period
 		"""
 	And the reqnroll.json configuration file contains
 		"""
@@ -161,5 +161,5 @@ Scenario: DefineSteps command properly escapes empty brackets when using Regex e
 	When I invoke the "Define Steps" command
 	Then the define steps dialog should be opened with the following step definition skeletons
 		| type | expression |
-		| When | I use \\(parenthesis\), \\{curly braces}, \\\ backslash, and/or \\. period |
+		| When | I use \\(parenthesis\), \\{curly braces}, \\\ backslash, \/ forwardslash, or \\. period |
 


### PR DESCRIPTION
Adds additional escape logic for forward slashes in regex

### 🤔 What's changed?

The c# Regex.Escape method is pretty minimal and doesnt include all the escape characters possible. We already manully escape some other sequences. I can continue investigating if there are other options to overcome the underlying cucumber error.

### ⚡️ What's your motivation? 

Fixes #85

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

I'm not a regex guru, maybe forward slashes are valid regex and the cucumber error is the ultimate issue we want to fix? I think if we do not escape forward slashes, we need to consider adding the string start and end markers?

### 📋 Checklist:

- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

