### PR TITLE
Fix 95: Ambiguous step reported when definition matches via more than one tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## Improvements:
 
 ## Bug fixes:
-
-*Contributors of this release (in alphabetical order):* 
+* Fix: Ambiguous steps reported wehn definition matches via more than one tag (#95)
+*Contributors of this release (in alphabetical order):* @clrudolphi
 
 # v2025.1.256 - 2025-03-07
 

--- a/Reqnroll.VisualStudio/Discovery/ProjectBindingImplementationEqualityComparer.cs
+++ b/Reqnroll.VisualStudio/Discovery/ProjectBindingImplementationEqualityComparer.cs
@@ -1,0 +1,30 @@
+namespace Reqnroll.VisualStudio.Discovery; 
+public class ProjectBindingImplementationEqualityComparer : IEqualityComparer<ProjectBindingImplementation>
+{
+    public bool Equals(ProjectBindingImplementation x, ProjectBindingImplementation y)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (x is null || y is null) return false;
+
+        return x.Method == y.Method &&
+               x.ParameterTypes.SequenceEqual(y.ParameterTypes) &&
+               Equals(x.SourceLocation, y.SourceLocation);
+    }
+
+    public int GetHashCode(ProjectBindingImplementation obj)
+    {
+        if (obj is null) return 0;
+
+        unchecked // Use unchecked to handle potential integer overflow
+        {
+            int hash = 17;
+            hash = hash * 23 + (obj.Method?.GetHashCode() ?? 0);
+
+            foreach (var paramType in obj.ParameterTypes)
+                hash = hash * 23 + (paramType?.GetHashCode() ?? 0);
+
+            hash = hash * 23 + (obj.SourceLocation?.GetHashCode() ?? 0);
+            return hash;
+        }
+    }
+}

--- a/Reqnroll.VisualStudio/Discovery/ProjectBindingRegistry.cs
+++ b/Reqnroll.VisualStudio/Discovery/ProjectBindingRegistry.cs
@@ -186,7 +186,14 @@ public record ProjectBindingRegistry
             var matchesWithScope = sdMatches.Where(m =>
                 m.MatchedStepDefinition.Scope != null).ToArray();
             if (matchesWithScope.Any())
-                sdMatches = matchesWithScope;
+            {
+                // Group matches by everything except the Scope property
+                // and take the first item from each group
+                sdMatches = matchesWithScope
+                    .GroupBy(m => m.MatchedStepDefinition.Implementation)
+                    .Select(g => g.First())
+                    .ToArray();
+            }
         }
 
         return sdMatches;

--- a/Reqnroll.VisualStudio/Discovery/ProjectBindingRegistry.cs
+++ b/Reqnroll.VisualStudio/Discovery/ProjectBindingRegistry.cs
@@ -7,6 +7,7 @@ public record ProjectBindingRegistry
     private const string DocStringDefaultTypeName = TypeShortcuts.StringType;
     public static ProjectBindingRegistry Invalid = new(ImmutableArray<ProjectStepDefinitionBinding>.Empty, ImmutableArray<ProjectHookBinding>.Empty);
 
+    private static ProjectBindingImplementationEqualityComparer _equalityComparerForProjectBindingImplementations = new();
     private static int _versionCounter;
 
     private ProjectBindingRegistry(IEnumerable<ProjectStepDefinitionBinding> stepDefinitions, IEnumerable<ProjectHookBinding> hooks)
@@ -190,7 +191,7 @@ public record ProjectBindingRegistry
                 // Group matches by everything except the Scope property
                 // and take the first item from each group
                 sdMatches = matchesWithScope
-                    .GroupBy(m => m.MatchedStepDefinition.Implementation)
+                    .GroupBy(m => m.MatchedStepDefinition.Implementation, _equalityComparerForProjectBindingImplementations)
                     .Select(g => g.First())
                     .ToArray();
             }

--- a/Tests/Reqnroll.VisualStudio.Specs/Features/Editor/StepAnalysis.feature
+++ b/Tests/Reqnroll.VisualStudio.Specs/Features/Editor/StepAnalysis.feature
@@ -274,6 +274,33 @@ Scenario: Matches combination scoped step definitions
 		"""
 	And no binding error should be highlighted
 
+Scenario: Matches on multiple tags (without improperly highlighting as Ambiguous)
+	Given there is a Reqnroll project scope
+	And the following step definitions in the project:
+		| type | regex                               | tag scope          |
+		| When | I use a step with multiple tags     | @mytag1,@mytag2    |
+	When the following feature file is opened in the editor
+		"""
+		Feature: Addition
+
+		@mytag1
+		@mytag2
+		Scenario: Random scenario
+			When I use a step with multiple tags
+
+		"""
+	And the project is built and the initial binding discovery is performed
+	Then all section of types DefinedStep should be highlighted as
+		"""
+		Feature: Addition
+		
+		@mytag1
+		@mytag2
+		Scenario: Random scenario
+			When {DefinedStep}I use a step with multiple tags{/DefinedStep}
+		"""
+	And no binding error should be highlighted
+
 Scenario: Analyses all scopes of background steps
 	Given there is a Reqnroll project scope
 	And the following step definitions in the project:

--- a/Tests/Reqnroll.VisualStudio.Specs/Features/Editor/StepAnalysis.feature
+++ b/Tests/Reqnroll.VisualStudio.Specs/Features/Editor/StepAnalysis.feature
@@ -276,9 +276,9 @@ Scenario: Matches combination scoped step definitions
 
 Scenario: Matches on multiple tags (without improperly highlighting as Ambiguous)
 	Given there is a Reqnroll project scope
-	And the following step definitions in the project:
-		| type | regex                               | tag scope          |
-		| When | I use a step with multiple tags     | @mytag1,@mytag2    |
+	And the following step definition with mulitple Tag Scopes in the project:
+		| type | regex                               | tag scope         |
+		| When | I use a step with multiple tags     | @mytag1,@mytag2   |
 	When the following feature file is opened in the editor
 		"""
 		Feature: Addition

--- a/Tests/Reqnroll.VisualStudio.Specs/StepDefinitions/ProjectSystemSteps.cs
+++ b/Tests/Reqnroll.VisualStudio.Specs/StepDefinitions/ProjectSystemSteps.cs
@@ -27,7 +27,7 @@ public class ProjectSystemSteps : Steps
                 action(_ideScope.BackgroundTaskTokenSource.Token));
     }
 
-    private StubIdeActions ActionsMock => (StubIdeActions) _ideScope.Actions;
+    private StubIdeActions ActionsMock => (StubIdeActions)_ideScope.Actions;
 
     [Given(@"there is a Reqnroll project scope")]
     public void GivenThereIsAReqnrollProjectScope()
@@ -144,10 +144,15 @@ public class ProjectSystemSteps : Steps
         var line = _rnd.Next(1, 30);
         _projectScope.AddFile(filePath, string.Empty);
 
+        tableRow.TryGetValue("regex", out var regex);
+        tableRow.TryGetValue("type", out var stepType);
+
         var stepDefinition = new StepDefinition
         {
             Method = $"M{Guid.NewGuid():N}",
-            SourceLocation = filePath + $"|{line}|5"
+            SourceLocation = filePath + $"|{line}|5",
+            Type = stepType,
+            Regex = regex
         };
 
         tableRow.TryGetValue("tag scope", out var tagScopes);
@@ -180,20 +185,22 @@ public class ProjectSystemSteps : Steps
             var stepDef = new StepDefinition
             {
                 Method = stepDefinition.Method,
-                SourceLocation = stepDefinition.SourceLocation
+                SourceLocation = stepDefinition.SourceLocation,
+                Regex = stepDefinition.Regex,
+                Type = stepDefinition.Type,
+                Scope = new StepScope
+                {
+                    Tag = tagScope,
+                    FeatureTitle = featureScope,
+                    ScenarioTitle = scenarioScope
+                }
             };
-            stepDef.Scope = new StepScope
-            {
-                Tag = tagScope,
-                FeatureTitle = featureScope,
-                ScenarioTitle = scenarioScope
-            };
-            stepDefinitions.Add(stepDef);
-        }
+                stepDefinitions.Add(stepDef);
+            }
 
 
         return stepDefinitions.ToArray();
-    }
+        }
 
     private Hook CreateHookFromTableRow(DataTableRow tableRow)
     {
@@ -367,7 +374,7 @@ public class ProjectSystemSteps : Steps
     [When(@"I invoke the ""(.*)"" command without waiting for the tag changes")]
     public void WhenIInvokeTheCommandWithoutWaitingForTagger(string commandName)
     {
-        PerformCommand(commandName, waitForTager:false);
+        PerformCommand(commandName, waitForTager: false);
     }
 
     private void PerformCommand(string commandName, string parameter = null,
@@ -469,8 +476,8 @@ public class ProjectSystemSteps : Steps
                         taggerProvider,
                         new GherkinDocumentFormatter(),
                         new StubEditorConfigOptionsProvider());
-                _wpfTextView.SimulateType((AutoFormatTableCommand) _invokedCommand, parameter?[0] ?? '|',
-                        taggerProvider);
+                    _wpfTextView.SimulateType((AutoFormatTableCommand)_invokedCommand, parameter?[0] ?? '|',
+                            taggerProvider);
                     break;
                 }
             case "Define Steps":
@@ -656,7 +663,7 @@ public class ProjectSystemSteps : Steps
     [Then(@"all (.*) section should be highlighted as")]
     public void ThenTheStepKeywordsShouldBeHighlightedAs(string keywordType, string expectedContent)
     {
-        ThenAllSectionOfTypesShouldBeHighlightedAs(new[] {keywordType}, expectedContent);
+        ThenAllSectionOfTypesShouldBeHighlightedAs(new[] { keywordType }, expectedContent);
     }
 
     [Then(@"the tag links should target to the following URLs")]
@@ -664,7 +671,7 @@ public class ProjectSystemSteps : Steps
     {
         var tagSpans = GetVsTagSpans<UrlTag>(_wpfTextView,
             new DeveroomUrlTaggerProvider(CreateAggregatorFactory(), _ideScope)).ToArray();
-        var actualTagLinks = tagSpans.Select(t => new {Tag = t.Span.GetText(), URL = t.Tag.Url.ToString()});
+        var actualTagLinks = tagSpans.Select(t => new { Tag = t.Span.GetText(), URL = t.Tag.Url.ToString() });
         expectedTagLinksTable.CompareToSet(actualTagLinks);
     }
 
@@ -945,7 +952,7 @@ public class ProjectSystemSteps : Steps
         _completionBroker.Should().NotBeNull();
         var actualCompletions = _completionBroker.Completions
             .Where(c => filter?.Invoke(c.InsertionText) ?? true)
-            .Select(c => new {Item = c.InsertionText.Trim(), c.Description});
+            .Select(c => new { Item = c.InsertionText.Trim(), c.Description });
 
         expectedItemsTable.CompareToSet(actualCompletions);
     }

--- a/Tests/Reqnroll.VisualStudio.Tests/Discovery/StubGherkinDocument.cs
+++ b/Tests/Reqnroll.VisualStudio.Tests/Discovery/StubGherkinDocument.cs
@@ -12,3 +12,24 @@ public sealed record StubGherkinDocument : IGherkinDocumentContext
     public IGherkinDocumentContext Parent => null!;
     public object Node => null!;
 }
+
+public record StubGherkinDocumentWithScope : IGherkinDocumentContext
+{
+    public static StubGherkinDocumentWithScope Instance { get; } = new();
+
+    public IGherkinDocumentContext Parent => null;
+
+    public object Node => new Scenario(
+        new[]
+        {
+            new Tag(new Gherkin.Ast.Location(0, 0), "@mytag1"),
+            new Tag(new Gherkin.Ast.Location(0, 0), "@mytag2")
+        },
+        null,
+        "Scenario ",
+        "Scenario with Scopes",
+        null,
+        null,
+        null
+    );
+}


### PR DESCRIPTION
### 🤔 What's changed?

Modified the ProjectBindingRegistry to ignore duplicate matches when the Implementations were the same but differed only in the Scope of the match.

### ⚡️ What's your motivation? 

Fixes #95 

### 🏷️ What kind of change is this?


- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?


### 📋 Checklist:


- [X] I've changed the behaviour of the code
  - [X] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X] Users should know about my change
  - [X] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
