### PR TITLE
Prefix generated regexes with a caret (`^`) to ensure they are not interpreted as Cucumber expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Improvements:
 
+* Generated regexes are prefixed with a caret (`^`) to ensure they are not interpreted as Cucumber expressions. (#98)
+
 ## Bug fixes:
 
-*Contributors of this release (in alphabetical order):* 
+*Contributors of this release (in alphabetical order):* @304NotModified
 
 # v2025.1.256 - 2025-03-07
 

--- a/Reqnroll.VisualStudio/Snippets/Fallback/RegexStepDefinitionSkeletonProvider.cs
+++ b/Reqnroll.VisualStudio/Snippets/Fallback/RegexStepDefinitionSkeletonProvider.cs
@@ -11,7 +11,8 @@ public class RegexStepDefinitionSkeletonProvider : DeveroomStepDefinitionSkeleto
 
     protected override string GetExpression(AnalyzedStepText stepText)
     {
-        StringBuilder result = new StringBuilder();
+        // Prefix regex with ^ to ensure that it's detected as regex instead of a cucumber expression.  
+        StringBuilder result = new StringBuilder("^");
 
         result.Append(EscapeRegex(stepText.TextParts[0]));
         for (int i = 1; i < stepText.TextParts.Count; i++)

--- a/Tests/Reqnroll.VisualStudio.Specs/Features/Editor/Commands/DefineStepsCommand.feature
+++ b/Tests/Reqnroll.VisualStudio.Specs/Features/Editor/Commands/DefineStepsCommand.feature
@@ -125,7 +125,7 @@ Scenario: DefineSteps command abides by reqnroll.json configuration for regex sk
 		When I invoke the "Define Steps" command
 		Then the define steps dialog should be opened with the following step definition skeletons
 			| type  | expression                        |
-			| Given | the client added (.*) pcs to the basket |
+			| Given | ^the client added (.*) pcs to the basket |
 
 Scenario: DefineSteps command properly escapes empty brackets when using Cucumber expressions
 	Given there is a Reqnroll project scope
@@ -161,5 +161,5 @@ Scenario: DefineSteps command properly escapes empty brackets when using Regex e
 	When I invoke the "Define Steps" command
 	Then the define steps dialog should be opened with the following step definition skeletons
 		| type | expression |
-		| When | I use \\(parenthesis\), \\{curly braces}, \\\ backslash, and/or \\. period |
+		| When | ^I use \\(parenthesis\), \\{curly braces}, \\\ backslash, and/or \\. period |
 


### PR DESCRIPTION
### 🤔 What's changed?

 Prefix regex with ^ to ensure that it's detected as regex instead of a cucumber expression.  

### ⚡️ What's your motivation? 

Otherwise the expressions are sometimes interpreted as cucumber expression at runtime, which isn't correct

### 🏷️ What kind of change is this?


- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
