### PR TITLE
Update new project wizard to latest framework versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Improvements:
 
+* New Project Wizard references the latest versions of supported test frameworks and .Net frameworks
 * Format Document will now right-align numeric values in tables. This can be overridden to left align them by setting "gherkin_table_cell_right_align_numeric_content = false" in .editorconfig file within a [*.feature] section. 
 
 ## Bug fixes:

--- a/Reqnroll.VisualStudio.ProjectTemplate/ProjectTemplate.csproj
+++ b/Reqnroll.VisualStudio.ProjectTemplate/ProjectTemplate.csproj
@@ -7,17 +7,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />$if$ ('$unittestframework$' == 'xUnit')
-    <PackageReference Include="Reqnroll.xUnit" Version="2.2.1" />
-    <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1" />$endif$$if$ ('$unittestframework$' == 'NUnit')
-    <PackageReference Include="Reqnroll.NUnit" Version="2.2.1" />
-    <PackageReference Include="nunit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />$endif$$if$ ('$unittestframework$' == 'MSTest')
-    <PackageReference Include="Reqnroll.MsTest" Version="2.2.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />$endif$$if$ ('$fluentassertionsincluded$' == 'True')
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />$endif$
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />$if$ ('$unittestframework$' == 'xUnit')
+    <PackageReference Include="Reqnroll.xUnit" Version="3.0.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3" />$endif$$if$ ('$unittestframework$' == 'xUnit3')
+    <PackageReference Include="Reqnroll.xUnit3" Version="3.0.0" />
+    <PackageReference Include="xunit.v3" Version="3.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3" />$endif$$if$ ('$unittestframework$' == 'NUnit')
+    <PackageReference Include="Reqnroll.NUnit" Version="3.0.0" />
+    <PackageReference Include="nunit" Version="4.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />$endif$$if$ ('$unittestframework$' == 'MSTest')
+    <PackageReference Include="Reqnroll.MsTest" Version="3.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.10.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.10.2" />$endif$$if$ ('$unittestframework$' == 'TUnit')
+    <PackageReference Include="Reqnroll.TUnit" Version="3.0.0" />
+    <PackageReference Include="TUnit" Version="0.55.23" />$endif$$if$ ('$fluentassertionsincluded$' == 'True')
+    <PackageReference Include="FluentAssertions" Version="7.2.0" />$endif$
   </ItemGroup>
 
   <ItemGroup>

--- a/Reqnroll.VisualStudio.UI/Dialogs/AddNewReqnrollProjectDialog.xaml
+++ b/Reqnroll.VisualStudio.UI/Dialogs/AddNewReqnrollProjectDialog.xaml
@@ -227,8 +227,8 @@
                                 <ComboBoxItem Tag="net462">.NET Framework 4.6.2</ComboBoxItem>
                                 <ComboBoxItem Tag="net472">.NET Framework 4.7.2</ComboBoxItem>
                                 <ComboBoxItem Tag="net48">.NET Framework 4.8.1</ComboBoxItem>
-								<ComboBoxItem Tag="net8.0">.NET 8.0</ComboBoxItem>
-                                <ComboBoxItem Tag="net9.0" IsSelected="True">.NET 9.0</ComboBoxItem>
+                                <ComboBoxItem Tag="net8.0" IsSelected="True">.NET 8.0</ComboBoxItem>
+                                <ComboBoxItem Tag="net9.0">.NET 9.0</ComboBoxItem>
                             </ComboBox>
 						</StackPanel>
 

--- a/Reqnroll.VisualStudio.UI/Dialogs/AddNewReqnrollProjectDialog.xaml
+++ b/Reqnroll.VisualStudio.UI/Dialogs/AddNewReqnrollProjectDialog.xaml
@@ -225,8 +225,11 @@
 							          Margin="0,0,0,0" Padding="8,8,8,8" SelectedValue="{Binding DotNetFramework}"
 							          IsSynchronizedWithCurrentItem="True">
                                 <ComboBoxItem Tag="net462">.NET Framework 4.6.2</ComboBoxItem>
+                                <ComboBoxItem Tag="net47">.NET Framework 4.7</ComboBoxItem>
+                                <ComboBoxItem Tag="net471">.NET Framework 4.7.1</ComboBoxItem>
                                 <ComboBoxItem Tag="net472">.NET Framework 4.7.2</ComboBoxItem>
-                                <ComboBoxItem Tag="net48">.NET Framework 4.8.1</ComboBoxItem>
+                                <ComboBoxItem Tag="net48">.NET Framework 4.8</ComboBoxItem>
+                                <ComboBoxItem Tag="net481">.NET Framework 4.8.1</ComboBoxItem>
                                 <ComboBoxItem Tag="net8.0" IsSelected="True">.NET 8.0</ComboBoxItem>
                                 <ComboBoxItem Tag="net9.0">.NET 9.0</ComboBoxItem>
                             </ComboBox>

--- a/Reqnroll.VisualStudio.UI/Dialogs/AddNewReqnrollProjectDialog.xaml
+++ b/Reqnroll.VisualStudio.UI/Dialogs/AddNewReqnrollProjectDialog.xaml
@@ -225,15 +225,10 @@
 							          Margin="0,0,0,0" Padding="8,8,8,8" SelectedValue="{Binding DotNetFramework}"
 							          IsSynchronizedWithCurrentItem="True">
                                 <ComboBoxItem Tag="net462">.NET Framework 4.6.2</ComboBoxItem>
-                                <ComboBoxItem Tag="net47">.NET Framework 4.7</ComboBoxItem>
-                                <ComboBoxItem Tag="net471">.NET Framework 4.7.1</ComboBoxItem>
                                 <ComboBoxItem Tag="net472">.NET Framework 4.7.2</ComboBoxItem>
-                                <ComboBoxItem Tag="net48">.NET Framework 4.8</ComboBoxItem>
                                 <ComboBoxItem Tag="net48">.NET Framework 4.8.1</ComboBoxItem>
-								<ComboBoxItem Tag="net6.0">.NET 6.0</ComboBoxItem>
-								<ComboBoxItem Tag="net7.0">.NET 7.0</ComboBoxItem>
-								<ComboBoxItem Tag="net8.0" IsSelected="True">.NET 8.0</ComboBoxItem>
-                                <ComboBoxItem Tag="net9.0">.NET 9.0</ComboBoxItem>
+								<ComboBoxItem Tag="net8.0">.NET 8.0</ComboBoxItem>
+                                <ComboBoxItem Tag="net9.0" IsSelected="True">.NET 9.0</ComboBoxItem>
                             </ComboBox>
 						</StackPanel>
 

--- a/Reqnroll.VisualStudio/UI/ViewModels/AddNewReqnrollProjectViewModel.cs
+++ b/Reqnroll.VisualStudio/UI/ViewModels/AddNewReqnrollProjectViewModel.cs
@@ -15,7 +15,7 @@ public class AddNewReqnrollProjectViewModel : INotifyPropertyChanged
         FluentAssertionsIncluded = false
     };
 #endif
-    private string _dotNetFramework = Net9;
+    private string _dotNetFramework = Net8;
 
     public string DotNetFramework
     {

--- a/Reqnroll.VisualStudio/UI/ViewModels/AddNewReqnrollProjectViewModel.cs
+++ b/Reqnroll.VisualStudio/UI/ViewModels/AddNewReqnrollProjectViewModel.cs
@@ -5,16 +5,17 @@ public class AddNewReqnrollProjectViewModel : INotifyPropertyChanged
 {
     private const string MsTest = "MsTest";
     private const string Net8 = "net8.0";
+    private const string Net9 = "net9.0";
 
 #if DEBUG
     public static AddNewReqnrollProjectViewModel DesignData = new()
     {
-        DotNetFramework = Net8,
+        DotNetFramework = Net9,
         UnitTestFramework = MsTest,
         FluentAssertionsIncluded = false
     };
 #endif
-    private string _dotNetFramework = Net8;
+    private string _dotNetFramework = Net9;
 
     public string DotNetFramework
     {
@@ -31,7 +32,7 @@ public class AddNewReqnrollProjectViewModel : INotifyPropertyChanged
     // See https://xceed.com/fluent-assertions-faq/
     // Maybe we could consider suggesting https://github.com/shouldly/shouldly instead.
     public bool FluentAssertionsIncluded { get; set; } = false;
-    public ObservableCollection<string> TestFrameworks { get; } = new(new List<string> { "MSTest", "NUnit", "xUnit" });
+    public ObservableCollection<string> TestFrameworks { get; } = new(new List<string> { "MSTest", "NUnit", "xUnit", "xUnit.v3", "TUnit" });
 
     public event PropertyChangedEventHandler PropertyChanged;
 


### PR DESCRIPTION
### 🤔 What's changed?

Updated `<PackageReference>` for the latest versions of test frameworks (including referencing the v3 version of the respective Reqnroll plugin).
Updated the default .Net framework in the selection dropdown to be .Net9.0.
Removed older versions of .Net frameworks (whose support were deprecated in Renqroll v3).

### ⚡️ What's your motivation? 

Keep the VS Extension in sync with Reqnroll v3 (#112 )

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

- [X] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X] Users should know about my change
  - [X] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
