### PR TITLE
Remove xunit3 (for now)

### DIFF
--- a/Reqnroll.VisualStudio.ProjectTemplate/ProjectTemplate.csproj
+++ b/Reqnroll.VisualStudio.ProjectTemplate/ProjectTemplate.csproj
@@ -10,9 +10,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />$if$ ('$unittestframework$' == 'xUnit')
     <PackageReference Include="Reqnroll.xUnit" Version="3.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3" />$endif$$if$ ('$unittestframework$' == 'xUnit3')
-    <PackageReference Include="Reqnroll.xUnit3" Version="3.0.0" />
-    <PackageReference Include="xunit.v3" Version="3.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3" />$endif$$if$ ('$unittestframework$' == 'NUnit')
     <PackageReference Include="Reqnroll.NUnit" Version="3.0.0" />
     <PackageReference Include="nunit" Version="4.4.0" />

--- a/Reqnroll.VisualStudio/UI/ViewModels/AddNewReqnrollProjectViewModel.cs
+++ b/Reqnroll.VisualStudio/UI/ViewModels/AddNewReqnrollProjectViewModel.cs
@@ -32,7 +32,7 @@ public class AddNewReqnrollProjectViewModel : INotifyPropertyChanged
     // See https://xceed.com/fluent-assertions-faq/
     // Maybe we could consider suggesting https://github.com/shouldly/shouldly instead.
     public bool FluentAssertionsIncluded { get; set; } = false;
-    public ObservableCollection<string> TestFrameworks { get; } = new(new List<string> { "MSTest", "NUnit", "xUnit", "xUnit.v3", "TUnit" });
+    public ObservableCollection<string> TestFrameworks { get; } = new(new List<string> { "MSTest", "NUnit", "xUnit", "TUnit" });
 
     public event PropertyChangedEventHandler PropertyChanged;
 


### PR DESCRIPTION
### 🤔 What's changed?

Removed xunit3 for now

### ⚡️ What's your motivation? 

https://github.com/reqnroll/Reqnroll/pull/538 hasn't merged yet and I think we should release a new version of this plugin before the release of the xUnit 3 support.

When https://github.com/reqnroll/Reqnroll/pull/538 is merged and released, then we could revert this PR :)

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->


- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)


