### PR TITLE
Remove .NET 6.0 tests to avoid GH build failures

### DIFF
--- a/Tests/Connector/Reqnroll.VisualStudio.ReqnrollConnector.Tests/AssemblyLoadingTests.cs
+++ b/Tests/Connector/Reqnroll.VisualStudio.ReqnrollConnector.Tests/AssemblyLoadingTests.cs
@@ -73,7 +73,7 @@ public class AssemblyLoadingTests
 
         //act
         var loadedAssembly = loadContext.LoadFromAssemblyName(new AssemblyName("Microsoft.AspNetCore.Antiforgery")
-            {Version = new Version(6, 0)});
+            {Version = new Version(8, 0)});
 
         //assert
         loadedAssembly.GetName().Name.Should().Be("Microsoft.AspNetCore.Antiforgery");

--- a/Tests/Reqnroll.VisualStudio.Specs/Features/Discovery/DiscoveryPlatformCompatibility.feature
+++ b/Tests/Reqnroll.VisualStudio.Specs/Features/Discovery/DiscoveryPlatformCompatibility.feature
@@ -9,6 +9,5 @@ Scenario Outline: Discover bindings from a Reqnroll project in different .NET Co
 	Then the discovery succeeds with several step definitions
 Examples: 
 	| framework |
-	| net6.0    |
 	| net8.0    |
 	| net9.0    |

--- a/Tests/Reqnroll.VisualStudio.Specs/Features/Discovery/SourceLocationDiscovery.feature
+++ b/Tests/Reqnroll.VisualStudio.Specs/Features/Discovery/SourceLocationDiscovery.feature
@@ -25,6 +25,5 @@ Scenario Outline: Discover binding source location from Reqnroll project with as
 Examples:
 	| framework |
 	| net481    |
-	| net6.0    |
 	| net8.0    |
 	| net9.0    |


### PR DESCRIPTION
### 🤔 What's changed?

Remove .NET 6.0 tests to avoid GH build failures

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
