### PR TITLE
Updated test framework package references to latest

### DIFF
--- a/Reqnroll.VisualStudio.ProjectTemplate/ProjectTemplate.csproj
+++ b/Reqnroll.VisualStudio.ProjectTemplate/ProjectTemplate.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />$endif$$if$ ('$unittestframework$' == 'MSTest')
     <PackageReference Include="Reqnroll.MsTest" Version="3.3.3" />
     <PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.1.2" />$endif$$if$ ('$unittestframework$' == 'TUnit')
+    <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />$endif$$if$ ('$unittestframework$' == 'TUnit')
     <PackageReference Include="Reqnroll.TUnit" Version="3.3.3" />
     <PackageReference Include="TUnit" Version="1.20.0" />$endif$$if$ ('$fluentassertionsincluded$' == 'True')
     <PackageReference Include="FluentAssertions" Version="7.2.0" />$endif$

--- a/Reqnroll.VisualStudio.ProjectTemplate/ProjectTemplate.csproj
+++ b/Reqnroll.VisualStudio.ProjectTemplate/ProjectTemplate.csproj
@@ -10,20 +10,20 @@
 
   <ItemGroup>$if$ ('$unittestframework$' != 'TUnit')
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />$endif$$if$ ('$unittestframework$' == 'xUnit')
-    <PackageReference Include="Reqnroll.xUnit" Version="3.2.0" />
+    <PackageReference Include="Reqnroll.xUnit" Version="3.3.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3" />$endif$$if$ ('$unittestframework$' == 'xUnit.v3')
-    <PackageReference Include="Reqnroll.xunit.v3" Version="3.2.0" />
-    <PackageReference Include="xunit.v3" Version="3.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3" />$endif$$if$ ('$unittestframework$' == 'NUnit')
-    <PackageReference Include="Reqnroll.NUnit" Version="3.2.0" />
-    <PackageReference Include="nunit" Version="4.4.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />$endif$$if$ ('$unittestframework$' == 'MSTest')
-    <PackageReference Include="Reqnroll.MsTest" Version="3.2.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.10.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.10.2" />$endif$$if$ ('$unittestframework$' == 'TUnit')
-    <PackageReference Include="Reqnroll.TUnit" Version="3.3.0" />
-    <PackageReference Include="TUnit" Version="1.19.74" />$endif$$if$ ('$fluentassertionsincluded$' == 'True')
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />$endif$$if$ ('$unittestframework$' == 'xUnit.v3')
+    <PackageReference Include="Reqnroll.xunit.v3" Version="3.3.3" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />$endif$$if$ ('$unittestframework$' == 'NUnit')
+    <PackageReference Include="Reqnroll.NUnit" Version="3.3.3" />
+    <PackageReference Include="nunit" Version="4.5.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />$endif$$if$ ('$unittestframework$' == 'MSTest')
+    <PackageReference Include="Reqnroll.MsTest" Version="3.3.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.1.2" />$endif$$if$ ('$unittestframework$' == 'TUnit')
+    <PackageReference Include="Reqnroll.TUnit" Version="3.3.3" />
+    <PackageReference Include="TUnit" Version="1.20.0" />$endif$$if$ ('$fluentassertionsincluded$' == 'True')
     <PackageReference Include="FluentAssertions" Version="7.2.0" />$endif$
   </ItemGroup>
 


### PR DESCRIPTION

### 🤔 What's changed?

Modified the New Project wizard configuration to reference the latest versions of the test execution frameworks.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?



### 📋 Checklist:

- [X] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
