### PR TITLE
Fix connector tests by excluding SpecFlowCompatibility tests from exploratory tests

### DIFF
--- a/Tests/Connector/Reqnroll.VisualStudio.ReqnrollConnector.Tests/ExternalSampleTests.cs
+++ b/Tests/Connector/Reqnroll.VisualStudio.ReqnrollConnector.Tests/ExternalSampleTests.cs
@@ -18,7 +18,7 @@ public class ExternalSampleTests : SampleProjectTestBase
     }
 
     private const string IgnoredExploratoryTestProjects =
-        "SpecFlowCompatibilityProject.Net472;CleanReqnrollProject.Net481.x86;VsExtConnectorTestSamples.NetFwSystemDataDep";
+        "SpecFlowCompatibilityProject.Net8;SpecFlowCompatibilityProject.Net10;SpecFlowCompatibilityProject.Net472;CleanReqnrollProject.Net481.x86;VsExtConnectorTestSamples.NetFwSystemDataDep";
 
     [Theory]
     [MemberData(nameof(GetProjectsForRepository), "https://github.com/reqnroll/Reqnroll.ExploratoryTestProjects", $"BigReqnrollProject;SpecFlowProject;OldProjectFileFormat.Empty;ReqnrollFormatters.CustomizedHtml;CustomPlugins.TagDecoratorGeneratorPlugin;{IgnoredExploratoryTestProjects}")]


### PR DESCRIPTION
### 🤔 What's changed?

Fix connector tests by excluding SpecFlowCompatibility tests from exploratory tests.

Fixes #168 

### ⚡️ What's your motivation? 

fix CI, that is broken because of a Reqnroll release issue: https://github.com/reqnroll/Reqnroll/issues/1068

Since SpecFlowCompatibility is going to be deprecated in Reqnroll v4, probably it is not worth doing connector smoke tests for that anymore. But we can re-enable these once the Reqnroll issue is fixed.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

- [x] I have added/updated tests to cover my changes.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
