### PR TITLE
Fix Reqnroll.VisualStudio 173 Regex modifiers treated as step parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -271,3 +271,4 @@ launchSettings.json
 
 /Tests/ExternalPackages/Reqnroll*.nupkg
 /.ncrunch/cache/
+/.claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Bug fixes:
 * Fix: Project Templates are broken for .NET Framework (#133)
 * Fix: TUnit projects should not include a package reference to Microsoft.NET.Test.Sdk (#134)
+* Fix: Regex modifiers are interfere with parameter identification in regex Step Expressions (#173)
 
 *Contributors of this release (in alphabetical order):* @clrudolphi
 

--- a/Reqnroll.VisualStudio/Editor/Services/StepDefinitions/RegexStepDefinitionExpressionAnalyzer.cs
+++ b/Reqnroll.VisualStudio/Editor/Services/StepDefinitions/RegexStepDefinitionExpressionAnalyzer.cs
@@ -3,6 +3,14 @@ namespace Reqnroll.VisualStudio.Editor.Services.StepDefinitions;
 
 public class RegexStepDefinitionExpressionAnalyzer : IStepDefinitionExpressionAnalyzer
 {
+    private enum TokenKind { Escape, CapturingGroup, NonCapturingGroup, UnscopedModifier, Operator }
+
+    private static readonly char[] MaskedRegexChars =
+        { '\\', '+', '.', '*', '?', '|', '{', '[', '(', '^', '$', '#' };
+
+    private static readonly HashSet<char> NcgOperatorChars =
+        new HashSet<char> { '+', '.', '*', '?', '|', '{', '[', '^', '$', '#' };
+
     public AnalyzedStepDefinitionExpression Parse(string expression)
     {
         var parts = SplitExpressionByGroups(expression);
@@ -12,61 +20,74 @@ public class RegexStepDefinitionExpressionAnalyzer : IStepDefinitionExpressionAn
     private ImmutableArray<AnalyzedStepDefinitionExpressionPart> SplitExpressionByGroups(string regexString)
     {
         var parts = new List<AnalyzedStepDefinitionExpressionPart>();
-        var escapedStringBuilder = new StringBuilder();
-        var unescapedStringBuilder = new StringBuilder();
-
-        var maskChar = '\\';
-        var groupOpenChar = '(';
-        var maskedRegexChars = new[] {maskChar, '+', '.', '*', '?', '|', '{', '[', groupOpenChar, '^', '$', '#'};
-        int position = 0;
+        var escaped = new StringBuilder();
+        var unescaped = new StringBuilder();
         bool isSimpleText = true;
+        int position = 0;
+
         while (position < regexString.Length)
         {
-            int index = regexString.IndexOfAny(maskedRegexChars, position);
+            int index = regexString.IndexOfAny(MaskedRegexChars, position);
             if (index < 0)
             {
-                var remainingText = regexString.Substring(position);
-                escapedStringBuilder.Append(remainingText);
-                unescapedStringBuilder.Append(remainingText);
+                var tail = regexString.Substring(position);
+                escaped.Append(tail);
+                unescaped.Append(tail);
                 break;
             }
 
-            if (regexString[index] == maskChar && index < regexString.Length - 1)
+            switch (ClassifyToken(regexString, index))
             {
-                escapedStringBuilder.Append(regexString.Substring(position, index - position + 2));
-                unescapedStringBuilder.Append(regexString.Substring(position, index - position));
-                unescapedStringBuilder.Append(regexString[index + 1]);
-                position = index + 2;
-            }
-            else if (regexString[index] == groupOpenChar && !IsNonCapturingGroup(regexString, index))
-            {
-                if (index > position)
+                case TokenKind.Escape:
+                    escaped.Append(regexString.Substring(position, index - position + 2));
+                    unescaped.Append(regexString.Substring(position, index - position));
+                    unescaped.Append(regexString[index + 1]);
+                    position = index + 2;
+                    break;
+
+                case TokenKind.CapturingGroup:
                 {
-                    var remainingText = regexString.Substring(position, index - position);
-                    escapedStringBuilder.Append(remainingText);
-                    unescapedStringBuilder.Append(remainingText);
+                    if (index > position)
+                    {
+                        var text = regexString.Substring(position, index - position);
+                        escaped.Append(text);
+                        unescaped.Append(text);
+                    }
+                    parts.Add(CreateTextPart(escaped.ToString(), unescaped.ToString(), isSimpleText));
+                    escaped = new StringBuilder();
+                    unescaped = new StringBuilder();
+                    isSimpleText = true;
+                    int groupEnd = FindGroupCloseIndex(regexString, index) + 1;
+                    parts.Add(new AnalyzedStepDefinitionExpressionParameterPart(
+                        regexString.Substring(index, groupEnd - index)));
+                    position = groupEnd;
+                    break;
                 }
 
-                parts.Add(CreateTextPart(escapedStringBuilder.ToString(), unescapedStringBuilder.ToString(),
-                    isSimpleText));
-                isSimpleText = true;
-                escapedStringBuilder = new StringBuilder();
-                unescapedStringBuilder = new StringBuilder();
-                var groupCloseIndex = FindGroupCloseIndex(regexString, index) + 1;
-                var parameter = regexString.Substring(index, groupCloseIndex - index);
-                parts.Add(new AnalyzedStepDefinitionExpressionParameterPart(parameter));
-                position = groupCloseIndex;
-            }
-            else
-            {
-                escapedStringBuilder.Append(regexString.Substring(position, index - position + 1));
-                unescapedStringBuilder.Append(regexString.Substring(position, index - position));
-                position = index + 1;
-                isSimpleText = false;
+                case TokenKind.NonCapturingGroup:
+                {
+                    var result = AppendNonCapturingGroup(regexString, index, position, escaped, unescaped);
+                    position = result.newPosition;
+                    if (NonCapturingGroupContentHasOperators(result.ncgString))
+                        isSimpleText = false;
+                    break;
+                }
+
+                case TokenKind.UnscopedModifier:
+                    position = AppendNonCapturingGroup(regexString, index, position, escaped, unescaped).newPosition;
+                    isSimpleText = false;
+                    break;
+
+                case TokenKind.Operator:
+                    escaped.Append(regexString.Substring(position, index - position + 1));
+                    unescaped.Append(regexString.Substring(position, index - position));
+                    position = index + 1;
+                    isSimpleText = false;
+                    break;
             }
         }
 
-        parts.Add(CreateTextPart(escapedStringBuilder.ToString(), unescapedStringBuilder.ToString(), isSimpleText));
+        parts.Add(CreateTextPart(escaped.ToString(), unescaped.ToString(), isSimpleText));
         return parts.ToImmutableArray();
     }
 
@@ -75,29 +96,122 @@ public class RegexStepDefinitionExpressionAnalyzer : IStepDefinitionExpressionAn
             ? new AnalyzedStepDefinitionExpressionSimpleTextPart(text, unescapedText)
             : new AnalyzedStepDefinitionExpressionWithOperatorsTextPart(text);
 
+    // Classifies the special character found at 'index' into a token the main loop can switch on.
+    // Combines the former IsNonCapturingGroup and IsUnscopedInlineModifier into one decision.
+    private TokenKind ClassifyToken(string regexString, int index)
+    {
+        char c = regexString[index];
+
+        if (c == '\\' && index < regexString.Length - 1) return TokenKind.Escape;
+        if (c != '(') return TokenKind.Operator;
+
+        // Not enough chars after '(' to be a special group — treat as a capturing group
+        if (index + 1 >= regexString.Length || regexString[index + 1] != '?')
+            return TokenKind.CapturingGroup;
+        if (index + 2 >= regexString.Length)
+            return TokenKind.CapturingGroup;
+
+        switch (regexString[index + 2])
+        {
+            case ':':
+            case '=':                    // (?=...) lookahead
+            case '!':                    // (?!...) negative lookahead
+            case '>':                    // (?>...) atomic group
+                return TokenKind.NonCapturingGroup;
+
+            case '<':                    // lookbehind (?<=...) or (?<!...) vs named group (?<name>...)
+                return index + 3 < regexString.Length &&
+                       (regexString[index + 3] == '=' || regexString[index + 3] == '!')
+                    ? TokenKind.NonCapturingGroup
+                    : TokenKind.CapturingGroup;
+
+            case '\'':                   // named group (?'name'...)
+                return TokenKind.CapturingGroup;
+        }
+
+        // Remaining candidate: inline option flags (?i), (?im), (?i:...), (?i-m:...), etc.
+        int pos = index + 2;
+        bool hasFlags = false;
+        while (pos < regexString.Length)
+        {
+            char flag = regexString[pos];
+            if (flag == 'i' || flag == 'm' || flag == 's' || flag == 'n' || flag == 'x' || flag == '-')
+            { hasFlags = true; pos++; }
+            else if (flag == ':') return hasFlags ? TokenKind.NonCapturingGroup : TokenKind.CapturingGroup;
+            else if (flag == ')') return hasFlags ? TokenKind.UnscopedModifier  : TokenKind.CapturingGroup;
+            else break;
+        }
+        return TokenKind.CapturingGroup;
+    }
+
+    // Flushes any pending text before the group, appends the NCG itself to both builders,
+    // and returns the new scan position along with the extracted group string.
+    private (int newPosition, string ncgString) AppendNonCapturingGroup(
+        string regexString, int index, int position,
+        StringBuilder escaped, StringBuilder unescaped)
+    {
+        if (index > position)
+        {
+            var textBefore = regexString.Substring(position, index - position);
+            escaped.Append(textBefore);
+            unescaped.Append(textBefore);
+        }
+        int closeIndex = FindGroupCloseIndex(regexString, index) + 1;
+        var ncg = regexString.Substring(index, closeIndex - index);
+        escaped.Append(ncg);
+        unescaped.Append(ncg);
+        return (closeIndex, ncg);
+    }
+
     private int FindGroupCloseIndex(string regexString, int openPosition)
     {
         int nesting = 0;
         for (int i = openPosition; i < regexString.Length; i++)
-            if (regexString[i] == '\\')
-            {
-                i++;
-            }
-            else if (regexString[i] == '(')
-            {
-                nesting++;
-            }
-            else if (regexString[i] == ')')
-            {
-                nesting--;
-                if (nesting == 0)
-                    return i;
-            }
-
+        {
+            if (regexString[i] == '\\') i++;
+            else if (regexString[i] == '(') nesting++;
+            else if (regexString[i] == ')') { nesting--; if (nesting == 0) return i; }
+        }
         return regexString.Length - 1;
     }
 
-    private bool IsNonCapturingGroup(string regexString, int index) =>
-        index + 2 < regexString.Length &&
-        regexString[index + 1] == '?' && regexString[index + 2] == ':';
+    // Returns true when the NCG's inner content contains unescaped regex operator characters,
+    // which means the surrounding text part cannot be treated as plain text.
+    private bool NonCapturingGroupContentHasOperators(string ncg)
+    {
+        int contentStart = FindNcgContentStart(ncg);
+        if (contentStart < 0) return false;
+
+        for (int i = contentStart; i < ncg.Length - 1; i++) // stop before closing ')'
+        {
+            if (ncg[i] == '\\') { i++; continue; }
+            if (NcgOperatorChars.Contains(ncg[i])) return true;
+        }
+        return false;
+    }
+
+    // Locates the index in 'ncg' where the actual match content begins,
+    // i.e. after the opening (? marker, any inline flags, and the type separator.
+    private static int FindNcgContentStart(string ncg)
+    {
+        int pos = 2; // skip "(?"
+        while (pos < ncg.Length && "imsnx-".IndexOf(ncg[pos]) >= 0)
+            pos++;
+
+        if (pos >= ncg.Length) return -1;
+
+        switch (ncg[pos])
+        {
+            case ')': return -1;      // unscoped modifier — no content, e.g. (?i)
+            case ':':
+            case '=':                 // (?=...) lookahead
+            case '!':                 // (?!...) negative lookahead
+            case '>': return pos + 1; // (?>...) atomic group, or (?:...) / (?i:...) NCG
+            case '<':                 // (?<=...) or (?<!...) lookbehind
+                return pos + 1 < ncg.Length && (ncg[pos + 1] == '=' || ncg[pos + 1] == '!')
+                    ? pos + 2
+                    : -1;
+            default: return -1;
+        }
+    }
 }

--- a/Tests/Reqnroll.VisualStudio.Tests/Editor/Completions/StepDefinitionSamplerTests.cs
+++ b/Tests/Reqnroll.VisualStudio.Tests/Editor/Completions/StepDefinitionSamplerTests.cs
@@ -35,6 +35,7 @@ public class StepDefinitionSamplerTests
         "I have entered [int] and [???] into the calculator", "System.Int32")]
     [InlineData("I have entered (.*) and ([^\"]*) into the calculator",
         "I have entered [int] and [string] into the calculator", "System.Int32", "System.String")]
+    [InlineData("(?i:a)nd (.*) into the calculator", "(?i:a)nd [int] into the calculator", "System.Int32")]
     public void Emits_param_placeholders(string regex, string expectedResult, params string[] paramType)
     {
         var sut = new StepDefinitionSampler();
@@ -80,6 +81,9 @@ public class StepDefinitionSamplerTests
     [InlineData(@"foo. (\d+) bar")]
     [InlineData(@"foo* (\d+) bar")]
     [InlineData(@"foo+ (\d+) bar")]
+    // Should pass through regex modifiers without trying to parse them as parameters
+    [InlineData(@"(?i)foo bar")]
+    [InlineData(@"(?i:f)oo bar")]
     public void Falls_back_to_regex(string regex)
     {
         var sut = new StepDefinitionSampler();

--- a/Tests/Reqnroll.VisualStudio.Tests/Editor/Services/StepDefinitions/RegexStepDefinitionExpressionAnalyzerTests.cs
+++ b/Tests/Reqnroll.VisualStudio.Tests/Editor/Services/StepDefinitions/RegexStepDefinitionExpressionAnalyzerTests.cs
@@ -1,0 +1,357 @@
+﻿#nullable disable
+using Reqnroll.VisualStudio.Editor.Services.StepDefinitions;
+
+namespace Reqnroll.VisualStudio.Tests.Editor.Services.StepDefinitions;
+
+public class RegexStepDefinitionExpressionAnalyzerTests
+{
+    [Fact]
+    public void Parse_SimpleText_ReturnsSimpleTextPart()
+    {
+        var sut = new RegexStepDefinitionExpressionAnalyzer();
+
+        var result = sut.Parse("I press add");
+
+        result.Parts.Should().HaveCount(1);
+        result.Parts[0].Should().BeOfType<AnalyzedStepDefinitionExpressionSimpleTextPart>();
+        var part = (AnalyzedStepDefinitionExpressionSimpleTextPart)result.Parts[0];
+        part.Text.Should().Be("I press add");
+        part.UnescapedText.Should().Be("I press add");
+    }
+
+    [Fact]
+    public void Parse_EmptyString_ReturnsEmptySimpleTextPart()
+    {
+        var sut = new RegexStepDefinitionExpressionAnalyzer();
+
+        var result = sut.Parse("");
+
+        result.Parts.Should().HaveCount(1);
+        result.Parts[0].Should().BeOfType<AnalyzedStepDefinitionExpressionSimpleTextPart>();
+        var part = (AnalyzedStepDefinitionExpressionSimpleTextPart)result.Parts[0];
+        part.Text.Should().Be("");
+        part.UnescapedText.Should().Be("");
+    }
+
+    [Theory]
+    [InlineData("I have (.*) apples", "I have ", "(.*)", " apples")]
+    [InlineData("(.*) is entered", "", "(.*)", " is entered")]
+    [InlineData("I press (.*)", "I press ", "(.*)", "")]
+    [InlineData("I have (.*) and (.*) apples", "I have ", "(.*)", " and ", "(.*)", " apples")]
+    public void Parse_WithCapturingGroups_SplitsIntoPartsCorrectly(string expression, params string[] expectedParts)
+    {
+        var sut = new RegexStepDefinitionExpressionAnalyzer();
+
+        var result = sut.Parse(expression);
+
+        result.Parts.Should().HaveCount(expectedParts.Length);
+        for (int i = 0; i < expectedParts.Length; i++)
+        {
+            result.Parts[i].ExpressionText.Should().Be(expectedParts[i], $"part {i} should match");
+        }
+    }
+
+    [Fact]
+    public void Parse_WithCapturingGroup_ReturnsParameterPart()
+    {
+        var sut = new RegexStepDefinitionExpressionAnalyzer();
+
+        var result = sut.Parse("I have (.*) apples");
+
+        result.Parts.Should().HaveCount(3);
+        result.Parts[0].Should().BeOfType<AnalyzedStepDefinitionExpressionSimpleTextPart>();
+        result.Parts[1].Should().BeOfType<AnalyzedStepDefinitionExpressionParameterPart>();
+        result.Parts[2].Should().BeOfType<AnalyzedStepDefinitionExpressionSimpleTextPart>();
+
+        var paramPart = (AnalyzedStepDefinitionExpressionParameterPart)result.Parts[1];
+        paramPart.ParameterExpression.Should().Be("(.*)");
+    }
+
+    [Theory]
+    [InlineData(@"some \(context\)", @"some \(context\)", "some (context)")]
+    [InlineData(@"some \{context\}", @"some \{context\}", "some {context}")]
+    [InlineData(@"some \[context\]", @"some \[context\]", "some [context]")]
+    [InlineData(@"chars \\\*\+\?\|\{\}\[\]\(\)\^\$\#", @"chars \\\*\+\?\|\{\}\[\]\(\)\^\$\#", @"chars \*+?|{}[]()^$#")]
+    public void Parse_WithEscapedChars_UnescapesCorrectly(string expression, string expectedText, string expectedUnescapedText)
+    {
+        var sut = new RegexStepDefinitionExpressionAnalyzer();
+
+        var result = sut.Parse(expression);
+
+        result.Parts.Should().HaveCount(1);
+        var part = (AnalyzedStepDefinitionExpressionSimpleTextPart)result.Parts[0];
+        part.Text.Should().Be(expectedText);
+        part.UnescapedText.Should().Be(expectedUnescapedText);
+    }
+
+    [Theory]
+    [InlineData(@"some \[context] (.*)", @"some \[context] ", "some [context] ", "(.*)", "")]
+    [InlineData(@"foo \\ (.+) bar", @"foo \\ ", @"foo \ ", "(.+)", " bar")]
+    public void Parse_WithEscapedCharsAndParameters_ProcessesBothCorrectly(string expression, string expectedText1, string expectedUnescaped1, string expectedParam, string expectedText2)
+    {
+        var sut = new RegexStepDefinitionExpressionAnalyzer();
+
+        var result = sut.Parse(expression);
+
+        result.Parts.Should().HaveCount(3);
+        var part1 = (AnalyzedStepDefinitionExpressionSimpleTextPart)result.Parts[0];
+        part1.Text.Should().Be(expectedText1);
+        part1.UnescapedText.Should().Be(expectedUnescaped1);
+
+        var paramPart = (AnalyzedStepDefinitionExpressionParameterPart)result.Parts[1];
+        paramPart.ParameterExpression.Should().Be(expectedParam);
+
+        var part2 = (AnalyzedStepDefinitionExpressionSimpleTextPart)result.Parts[2];
+        part2.ExpressionText.Should().Be(expectedText2);
+    }
+
+    [Theory]
+    [InlineData("(?:non-capturing) (.*)", "(?:non-capturing) ", "(.*)", "")]
+    [InlineData("foo (?:bar) (.*)", "foo (?:bar) ", "(.*)", "")]
+    [InlineData("(?:a|b) and (?:c|d)", "(?:a|b) and (?:c|d)")]
+    public void Parse_WithNonCapturingGroups_TreatsAsText(string expression, params string[] expectedParts)
+    {
+        var sut = new RegexStepDefinitionExpressionAnalyzer();
+
+        var result = sut.Parse(expression);
+
+        result.Parts.Should().HaveCount(expectedParts.Length);
+        for (int i = 0; i < expectedParts.Length; i++)
+        {
+            result.Parts[i].ExpressionText.Should().Be(expectedParts[i], $"part {i} should match");
+        }
+    }
+
+    [Theory]
+    [InlineData(@"foo (\d+) bar", "foo ", @"(\d+)", " bar")]
+    [InlineData(@"foo (?<hello>.(.)) bar", "foo ", @"(?<hello>.(.))", " bar")]
+    [InlineData(@"foo (?<name>\d+) bar", "foo ", @"(?<name>\d+)", " bar")]
+    public void Parse_WithNestedGroups_CapturesEntireGroup(string expression, params string[] expectedParts)
+    {
+        var sut = new RegexStepDefinitionExpressionAnalyzer();
+
+        var result = sut.Parse(expression);
+
+        result.Parts.Should().HaveCount(expectedParts.Length);
+        for (int i = 0; i < expectedParts.Length; i++)
+        {
+            result.Parts[i].ExpressionText.Should().Be(expectedParts[i], $"part {i} should match");
+        }
+    }
+
+    [Theory]
+    [InlineData(@"foo (?<hello>.\)(.)) bar", "foo ", @"(?<hello>.\)(.))", " bar")]
+    [InlineData(@"foo (a\)b) bar", "foo ", @"(a\)b)", " bar")]
+    public void Parse_WithEscapedParenthesesInGroup_HandlesCorrectly(string expression, params string[] expectedParts)
+    {
+        var sut = new RegexStepDefinitionExpressionAnalyzer();
+
+        var result = sut.Parse(expression);
+
+        result.Parts.Should().HaveCount(expectedParts.Length);
+        for (int i = 0; i < expectedParts.Length; i++)
+        {
+            result.Parts[i].ExpressionText.Should().Be(expectedParts[i], $"part {i} should match");
+        }
+    }
+
+    [Theory]
+    [InlineData("foo? (.*) bar", "foo? ", "(.*)", " bar")]
+    [InlineData("foo+ (.*) bar", "foo+ ", "(.*)", " bar")]
+    [InlineData("foo* (.*) bar", "foo* ", "(.*)", " bar")]
+    [InlineData("foo. (.*) bar", "foo. ", "(.*)", " bar")]
+    [InlineData("foo[a-z] (.*) bar", "foo[a-z] ", "(.*)", " bar")]
+    [InlineData("foo|bar (.*) baz", "foo|bar ", "(.*)", " baz")]
+    [InlineData("^foo (.*) bar$", "^foo ", "(.*)", " bar$")]
+    [InlineData("foo#comment (.*)", "foo#comment ", "(.*)", "")]
+    public void Parse_WithRegexOperators_CreatesWithOperatorsTextPart(string expression, params string[] expectedParts)
+    {
+        var sut = new RegexStepDefinitionExpressionAnalyzer();
+
+        var result = sut.Parse(expression);
+
+        result.Parts.Should().HaveCount(expectedParts.Length);
+
+        // First part should be WithOperators type
+        result.Parts[0].Should().BeOfType<AnalyzedStepDefinitionExpressionWithOperatorsTextPart>();
+        result.Parts[0].ExpressionText.Should().Be(expectedParts[0]);
+
+        // Verify all parts match
+        for (int i = 0; i < expectedParts.Length; i++)
+        {
+            result.Parts[i].ExpressionText.Should().Be(expectedParts[i], $"part {i} should match");
+        }
+    }
+
+    [Theory]
+    [InlineData("(very basic|standard|scientific)", "(very basic|standard|scientific)")]
+    [InlineData("( 1st| 2nd | 3 rd |4th)", "( 1st| 2nd | 3 rd |4th)")]
+    [InlineData("(a|b|c)", "(a|b|c)")]
+    public void Parse_WithPipeInCapturingGroup_RecognizesAsParameter(string expression, string expectedParam)
+    {
+        var sut = new RegexStepDefinitionExpressionAnalyzer();
+
+        var result = sut.Parse(expression);
+
+        result.Parts.Should().HaveCount(3); // empty text + parameter + empty text
+        result.Parts[1].Should().BeOfType<AnalyzedStepDefinitionExpressionParameterPart>();
+        var paramPart = (AnalyzedStepDefinitionExpressionParameterPart)result.Parts[1];
+        paramPart.ParameterExpression.Should().Be(expectedParam);
+    }
+
+    [Theory]
+    [InlineData("(.*) is entered into the (very basic|standard|scientific) calculator", "", "(.*)", " is entered into the ", "(very basic|standard|scientific)", " calculator")]
+    [InlineData("(.*) saved with name ([^']*)", "", "(.*)", " saved with name ", "([^']*)", "")]
+    public void Parse_MultipleParametersWithPipe_RecognizesBothAsParameters(string expression, params string[] expectedParts)
+    {
+        var sut = new RegexStepDefinitionExpressionAnalyzer();
+
+        var result = sut.Parse(expression);
+
+        result.Parts.Should().HaveCount(expectedParts.Length);
+        for (int i = 0; i < expectedParts.Length; i++)
+        {
+            result.Parts[i].ExpressionText.Should().Be(expectedParts[i], $"part {i} should match");
+        }
+    }
+
+    [Theory]
+    [InlineData("(?i)foo bar", "(?i)foo bar")]
+    [InlineData("(?i)foo (.*) bar", "(?i)foo ", "(.*)", " bar")]
+    [InlineData("(?m)^start", "(?m)^start")]
+    [InlineData("(?s)foo.bar", "(?s)foo.bar")]
+    public void Parse_WithInlineRegexOptions_IncludesOptionsInTextPart(string expression, params string[] expectedParts)
+    {
+        var sut = new RegexStepDefinitionExpressionAnalyzer();
+
+        var result = sut.Parse(expression);
+
+        result.Parts.Should().HaveCount(expectedParts.Length);
+        for (int i = 0; i < expectedParts.Length; i++)
+        {
+            result.Parts[i].ExpressionText.Should().Be(expectedParts[i], $"part {i} should match");
+        }
+
+        // The (?i) should be in a WithOperators part, not treated as a non-capturing group
+        if (expression.StartsWith("(?i)") || expression.StartsWith("(?m)") || expression.StartsWith("(?s)"))
+        {
+            result.Parts[0].Should().BeOfType<AnalyzedStepDefinitionExpressionWithOperatorsTextPart>();
+        }
+    }
+
+    [Theory]
+    [InlineData("(?i:foo) bar", "(?i:foo) bar")]
+    [InlineData("(?i:foo) (.*) bar", "(?i:foo) ", "(.*)", " bar")]
+    [InlineData("(?i:a)nd (.*) into the calculator", "(?i:a)nd ", "(.*)", " into the calculator")]
+    [InlineData("foo (?i:BAR) (.*)", "foo (?i:BAR) ", "(.*)", "")]
+    public void Parse_WithInlineRegexOptionsGroup_IncludesInTextPart(string expression, params string[] expectedParts)
+    {
+        var sut = new RegexStepDefinitionExpressionAnalyzer();
+
+        var result = sut.Parse(expression);
+
+        result.Parts.Should().HaveCount(expectedParts.Length);
+        for (int i = 0; i < expectedParts.Length; i++)
+        {
+            result.Parts[i].ExpressionText.Should().Be(expectedParts[i], $"part {i} should match");
+        }
+
+        // Verify that inline options groups are not treated as parameters
+        var paramParts = result.Parts.OfType<AnalyzedStepDefinitionExpressionParameterPart>().ToList();
+        paramParts.Should().NotContain(p => p.ParameterExpression.StartsWith("(?i:"));
+    }
+
+    [Theory]
+    [InlineData("(?i:a)nd (?i:b)ut (.*)", "(?i:a)nd (?i:b)ut ", "(.*)", "")]
+    [InlineData("(?:foo)(?i:bar)(.*)", "(?:foo)(?i:bar)", "(.*)", "")]
+    public void Parse_WithMultipleInlineOptionsGroups_HandlesCorrectly(string expression, params string[] expectedParts)
+    {
+        var sut = new RegexStepDefinitionExpressionAnalyzer();
+
+        var result = sut.Parse(expression);
+
+        result.Parts.Should().HaveCount(expectedParts.Length);
+        for (int i = 0; i < expectedParts.Length; i++)
+        {
+            result.Parts[i].ExpressionText.Should().Be(expectedParts[i], $"part {i} should match");
+        }
+    }
+
+    [Theory]
+    [InlineData("(?im:foo) (.*)", "(?im:foo) ", "(.*)", "")]
+    [InlineData("(?i-m:foo) (.*)", "(?i-m:foo) ", "(.*)", "")]
+    [InlineData("(?imnsx:test) bar", "(?imnsx:test) bar")]
+    public void Parse_WithMultipleRegexOptionFlags_RecognizesAsNonCapturingGroup(string expression, params string[] expectedParts)
+    {
+        var sut = new RegexStepDefinitionExpressionAnalyzer();
+
+        var result = sut.Parse(expression);
+
+        result.Parts.Should().HaveCount(expectedParts.Length);
+        for (int i = 0; i < expectedParts.Length; i++)
+        {
+            result.Parts[i].ExpressionText.Should().Be(expectedParts[i], $"part {i} should match");
+        }
+
+        // Verify these are not treated as parameters
+        var paramParts = result.Parts.OfType<AnalyzedStepDefinitionExpressionParameterPart>().ToList();
+        paramParts.Should().NotContain(p => p.ParameterExpression.Contains("(?i"));
+    }
+
+    [Fact]
+    public void Parse_WithUnmatchedOpeningParenthesis_HandlesGracefully()
+    {
+        var sut = new RegexStepDefinitionExpressionAnalyzer();
+
+        var result = sut.Parse("foo (.*");
+
+        result.Parts.Should().HaveCount(3);
+        result.Parts[0].Should().BeOfType<AnalyzedStepDefinitionExpressionSimpleTextPart>();
+        result.Parts[1].Should().BeOfType<AnalyzedStepDefinitionExpressionParameterPart>();
+        var paramPart = (AnalyzedStepDefinitionExpressionParameterPart)result.Parts[1];
+        paramPart.ParameterExpression.Should().Be("(.*"); // Captures to end of string
+    }
+
+    [Fact]
+    public void Parse_ContainsOnlySimpleText_ReturnsTrueForSimpleText()
+    {
+        var sut = new RegexStepDefinitionExpressionAnalyzer();
+
+        var result = sut.Parse("I press add");
+
+        result.ContainsOnlySimpleText.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Parse_ContainsOnlySimpleText_ReturnsTrueForSimpleTextWithParameters()
+    {
+        var sut = new RegexStepDefinitionExpressionAnalyzer();
+
+        var result = sut.Parse("I have (.*) apples");
+
+        result.ContainsOnlySimpleText.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Parse_ContainsOnlySimpleText_ReturnsFalseForRegexOperators()
+    {
+        var sut = new RegexStepDefinitionExpressionAnalyzer();
+
+        var result = sut.Parse("foo? (.*) bar");
+
+        result.ContainsOnlySimpleText.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_ParameterParts_ReturnsOnlyParameterParts()
+    {
+        var sut = new RegexStepDefinitionExpressionAnalyzer();
+
+        var result = sut.Parse("I have (.*) and (\\d+) items");
+
+        var paramParts = result.ParameterParts.ToList();
+        paramParts.Should().HaveCount(2);
+        paramParts[0].ParameterExpression.Should().Be("(.*)");
+        paramParts[1].ParameterExpression.Should().Be("(\\d+)");
+    }
+}


### PR DESCRIPTION
### 🤔 What's changed?

The `RegexStepDefinitionAnalyzer` was refactored to support the inclusion of regex modifiers.

The main logic flow was significantly restructured in an attempt to make it more human readable (eliminating nested IFs in favor of case statements).

### ⚡️ What's your motivation? 

Fix #173.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)


### ♻️ Anything particular you want feedback on?



### 📋 Checklist:



- [X] I've changed the behaviour of the code
  - [X] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
